### PR TITLE
Create SPM package with hybrid systemLibrary/binaryTarget architecture

### DIFF
--- a/.github/workflows/build-xcframeworks.yml
+++ b/.github/workflows/build-xcframeworks.yml
@@ -1,0 +1,233 @@
+name: Build XCFrameworks
+
+on:
+  workflow_dispatch:
+    inputs:
+      sfcgal_version:
+        description: "SFCGAL version to build (e.g., 2.0.0)"
+        required: true
+        default: "2.0.0"
+      gmp_version:
+        description: "GMP version (e.g., 6.3.0)"
+        required: true
+        default: "6.3.0"
+      mpfr_version:
+        description: "MPFR version (e.g., 4.2.1)"
+        required: true
+        default: "4.2.1"
+      create_release:
+        description: "Create a GitHub Release with the XCFrameworks"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build XCFrameworks
+    runs-on: macos-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install cmake automake autoconf libtool
+
+      - name: Show build environment
+        run: |
+          echo "Xcode: $(xcodebuild -version | head -1)"
+          echo "SDK: $(xcrun --sdk iphoneos --show-sdk-path)"
+          echo "CMake: $(cmake --version | head -1)"
+          echo "CPUs: $(sysctl -n hw.ncpu)"
+
+      # ── Cross-compile GMP ──────────────────────────────────────────────
+      - name: Build GMP for iOS
+        run: ./scripts/build-gmp-ios.sh gmp-ios-build
+        env:
+          GMP_VERSION_OVERRIDE: ${{ inputs.gmp_version }}
+
+      - name: Cache GMP build
+        uses: actions/cache/save@v4
+        with:
+          path: gmp-ios-build
+          key: gmp-${{ inputs.gmp_version }}-${{ runner.os }}
+
+      # ── Cross-compile MPFR ─────────────────────────────────────────────
+      - name: Build MPFR for iOS
+        run: ./scripts/build-mpfr-ios.sh gmp-ios-build mpfr-ios-build
+        env:
+          MPFR_VERSION_OVERRIDE: ${{ inputs.mpfr_version }}
+
+      - name: Cache MPFR build
+        uses: actions/cache/save@v4
+        with:
+          path: mpfr-ios-build
+          key: mpfr-${{ inputs.mpfr_version }}-${{ runner.os }}
+
+      # ── Cross-compile SFCGAL ───────────────────────────────────────────
+      - name: Build SFCGAL for iOS
+        run: ./scripts/build-sfcgal-ios.sh gmp-ios-build mpfr-ios-build sfcgal-ios-build
+        env:
+          SFCGAL_VERSION_OVERRIDE: ${{ inputs.sfcgal_version }}
+
+      # ── Create XCFrameworks ────────────────────────────────────────────
+      - name: Create XCFrameworks
+        run: ./scripts/create-xcframeworks.sh
+
+      # ── Verify XCFrameworks ────────────────────────────────────────────
+      - name: Verify XCFrameworks
+        run: |
+          echo "=== Checking XCFramework contents ==="
+          for fw in GMP MPFR SFCGAL; do
+            fw_path="xcframeworks/${fw}.xcframework"
+            if [ ! -d "$fw_path" ]; then
+              echo "ERROR: ${fw}.xcframework not found!"
+              exit 1
+            fi
+
+            echo "--- ${fw}.xcframework ---"
+
+            # Verify Info.plist exists and is valid
+            plutil -lint "${fw_path}/Info.plist"
+
+            # Check architectures
+            find "$fw_path" -name "*.a" | while read -r lib; do
+              echo "  $(basename "$lib"): $(lipo -info "$lib" 2>&1)"
+            done
+
+            # Check module maps
+            modulemap_count=$(find "$fw_path" -name "module.modulemap" | wc -l | tr -d ' ')
+            if [ "$modulemap_count" -lt 2 ]; then
+              echo "ERROR: Expected at least 2 module maps in ${fw}.xcframework, found $modulemap_count"
+              exit 1
+            fi
+            echo "  Module maps: $modulemap_count"
+            echo ""
+          done
+
+      # ── Zip XCFrameworks ───────────────────────────────────────────────
+      - name: Package XCFrameworks
+        run: |
+          cd xcframeworks
+          for fw in GMP MPFR SFCGAL; do
+            zip -r -y "${fw}.xcframework.zip" "${fw}.xcframework"
+            echo "${fw}.xcframework.zip: $(du -h "${fw}.xcframework.zip" | cut -f1)"
+          done
+
+      # ── Compute checksums ──────────────────────────────────────────────
+      - name: Compute checksums
+        id: checksums
+        run: |
+          cd xcframeworks
+          for fw in GMP MPFR SFCGAL; do
+            checksum=$(swift package compute-checksum "${fw}.xcframework.zip")
+            echo "${fw}_CHECKSUM=${checksum}" >> "$GITHUB_OUTPUT"
+            echo "${fw}: ${checksum}"
+          done
+
+      # ── Upload artifacts (always) ──────────────────────────────────────
+      - name: Upload XCFramework artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcframeworks-sfcgal-${{ inputs.sfcgal_version }}
+          path: |
+            xcframeworks/GMP.xcframework.zip
+            xcframeworks/MPFR.xcframework.zip
+            xcframeworks/SFCGAL.xcframework.zip
+          retention-days: 30
+
+      # ── Create GitHub Release ──────────────────────────────────────────
+      - name: Create GitHub Release
+        if: inputs.create_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SFCGAL_VERSION: ${{ inputs.sfcgal_version }}
+          GMP_VERSION: ${{ inputs.gmp_version }}
+          MPFR_VERSION: ${{ inputs.mpfr_version }}
+          GMP_CHECKSUM: ${{ steps.checksums.outputs.GMP_CHECKSUM }}
+          MPFR_CHECKSUM: ${{ steps.checksums.outputs.MPFR_CHECKSUM }}
+          SFCGAL_CHECKSUM: ${{ steps.checksums.outputs.SFCGAL_CHECKSUM }}
+        run: |
+          TAG="v${SFCGAL_VERSION}"
+
+          BODY="$(cat <<'HEREDOC'
+          ## XCFrameworks for iOS
+
+          Cross-compiled static libraries packaged as XCFrameworks for iOS device (arm64) and simulator (arm64 + x86_64).
+
+          ### Minimum Deployment Target
+          - iOS 15.0
+
+          ### Architectures
+          - **iOS Device:** arm64
+          - **iOS Simulator:** arm64 + x86_64 (fat binary)
+          HEREDOC
+          )"
+
+          # Append version table and checksums (needs variable expansion)
+          BODY="${BODY}
+
+          ### Library Versions
+          | Library | Version |
+          |---------|---------|
+          | SFCGAL  | ${SFCGAL_VERSION} |
+          | GMP     | ${GMP_VERSION} |
+          | MPFR    | ${MPFR_VERSION} |
+
+          ### Swift Package Manager Checksums
+          \`\`\`
+          GMP:    ${GMP_CHECKSUM}
+          MPFR:   ${MPFR_CHECKSUM}
+          SFCGAL: ${SFCGAL_CHECKSUM}
+          \`\`\`"
+
+          gh release create "$TAG" \
+            --title "SFCGAL ${SFCGAL_VERSION} XCFrameworks" \
+            --notes "$BODY" \
+            xcframeworks/GMP.xcframework.zip \
+            xcframeworks/MPFR.xcframework.zip \
+            xcframeworks/SFCGAL.xcframework.zip
+
+          echo "Release created: $TAG"
+          echo "RELEASE_TAG=${TAG}" >> "$GITHUB_OUTPUT"
+
+      # ── Print Package.swift snippet ────────────────────────────────────
+      - name: Print Package.swift binaryTarget snippet
+        if: inputs.create_release
+        env:
+          SFCGAL_VERSION: ${{ inputs.sfcgal_version }}
+          GMP_CHECKSUM: ${{ steps.checksums.outputs.GMP_CHECKSUM }}
+          MPFR_CHECKSUM: ${{ steps.checksums.outputs.MPFR_CHECKSUM }}
+          SFCGAL_CHECKSUM: ${{ steps.checksums.outputs.SFCGAL_CHECKSUM }}
+        run: |
+          REPO_URL="https://github.com/${{ github.repository }}"
+          TAG="v${SFCGAL_VERSION}"
+
+          cat <<EOF
+
+          ════════════════════════════════════════════════════════════════════
+          Add these binaryTarget entries to your Package.swift:
+          ════════════════════════════════════════════════════════════════════
+
+          .binaryTarget(
+              name: "CGMP",
+              url: "${REPO_URL}/releases/download/${TAG}/GMP.xcframework.zip",
+              checksum: "${GMP_CHECKSUM}"
+          ),
+          .binaryTarget(
+              name: "CMPFR",
+              url: "${REPO_URL}/releases/download/${TAG}/MPFR.xcframework.zip",
+              checksum: "${MPFR_CHECKSUM}"
+          ),
+          .binaryTarget(
+              name: "CSFCGAL",
+              url: "${REPO_URL}/releases/download/${TAG}/SFCGAL.xcframework.zip",
+              checksum: "${SFCGAL_CHECKSUM}"
+          ),
+
+          EOF

--- a/.github/workflows/build-xcframeworks.yml
+++ b/.github/workflows/build-xcframeworks.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       sfcgal_version:
-        description: "SFCGAL version to build (e.g., 2.0.0)"
+        description: "SFCGAL version to build (e.g., 2.2.0)"
         required: true
-        default: "2.0.0"
+        default: "2.2.0"
       gmp_version:
         description: "GMP version (e.g., 6.3.0)"
         required: true
@@ -15,11 +15,23 @@ on:
         description: "MPFR version (e.g., 4.2.1)"
         required: true
         default: "4.2.1"
+      release_type:
+        description: "Release type (dev = pre-release with suffix, stable = production)"
+        required: true
+        type: choice
+        options:
+          - dev
+          - stable
+        default: "dev"
+      dev_suffix:
+        description: "Dev pre-release number (e.g., 3 → v2.2.0-3). Only used when release_type=dev."
+        required: false
+        default: "1"
       create_release:
         description: "Create a GitHub Release with the XCFrameworks"
         required: true
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: write
@@ -130,11 +142,25 @@ jobs:
             echo "${fw}: ${checksum}"
           done
 
+      # ── Compute release tag ─────────────────────────────────────────────
+      - name: Compute release tag
+        id: tag
+        run: |
+          if [ "${{ inputs.release_type }}" = "dev" ]; then
+            TAG="v${{ inputs.sfcgal_version }}-${{ inputs.dev_suffix }}"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            TAG="v${{ inputs.sfcgal_version }}"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Computed tag: ${TAG}"
+
       # ── Upload artifacts (always) ──────────────────────────────────────
       - name: Upload XCFramework artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: xcframeworks-sfcgal-${{ inputs.sfcgal_version }}
+          name: xcframeworks-${{ steps.tag.outputs.tag }}
           path: |
             xcframeworks/GMP.xcframework.zip
             xcframeworks/MPFR.xcframework.zip
@@ -146,14 +172,20 @@ jobs:
         if: inputs.create_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          PRERELEASE: ${{ steps.tag.outputs.prerelease }}
           SFCGAL_VERSION: ${{ inputs.sfcgal_version }}
           GMP_VERSION: ${{ inputs.gmp_version }}
           MPFR_VERSION: ${{ inputs.mpfr_version }}
           GMP_CHECKSUM: ${{ steps.checksums.outputs.GMP_CHECKSUM }}
           MPFR_CHECKSUM: ${{ steps.checksums.outputs.MPFR_CHECKSUM }}
           SFCGAL_CHECKSUM: ${{ steps.checksums.outputs.SFCGAL_CHECKSUM }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
-          TAG="v${SFCGAL_VERSION}"
+          RELEASE_LABEL="SFCGAL ${SFCGAL_VERSION} XCFrameworks"
+          if [ "$RELEASE_TYPE" = "dev" ]; then
+            RELEASE_LABEL="${RELEASE_LABEL} (dev ${{ inputs.dev_suffix }})"
+          fi
 
           BODY="$(cat <<'HEREDOC'
           ## XCFrameworks for iOS
@@ -184,33 +216,44 @@ jobs:
           GMP:    ${GMP_CHECKSUM}
           MPFR:   ${MPFR_CHECKSUM}
           SFCGAL: ${SFCGAL_CHECKSUM}
+          \`\`\`
+
+          ### Package.swift binaryTarget URLs
+          \`\`\`
+          GMP:    https://github.com/${{ github.repository }}/releases/download/${TAG}/GMP.xcframework.zip
+          MPFR:   https://github.com/${{ github.repository }}/releases/download/${TAG}/MPFR.xcframework.zip
+          SFCGAL: https://github.com/${{ github.repository }}/releases/download/${TAG}/SFCGAL.xcframework.zip
           \`\`\`"
 
+          PRERELEASE_FLAG=""
+          if [ "$PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
           gh release create "$TAG" \
-            --title "SFCGAL ${SFCGAL_VERSION} XCFrameworks" \
+            --title "$RELEASE_LABEL" \
             --notes "$BODY" \
+            $PRERELEASE_FLAG \
             xcframeworks/GMP.xcframework.zip \
             xcframeworks/MPFR.xcframework.zip \
             xcframeworks/SFCGAL.xcframework.zip
 
-          echo "Release created: $TAG"
-          echo "RELEASE_TAG=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Release created: $TAG (prerelease=$PRERELEASE)"
 
       # ── Print Package.swift snippet ────────────────────────────────────
       - name: Print Package.swift binaryTarget snippet
-        if: inputs.create_release
         env:
-          SFCGAL_VERSION: ${{ inputs.sfcgal_version }}
+          TAG: ${{ steps.tag.outputs.tag }}
           GMP_CHECKSUM: ${{ steps.checksums.outputs.GMP_CHECKSUM }}
           MPFR_CHECKSUM: ${{ steps.checksums.outputs.MPFR_CHECKSUM }}
           SFCGAL_CHECKSUM: ${{ steps.checksums.outputs.SFCGAL_CHECKSUM }}
         run: |
           REPO_URL="https://github.com/${{ github.repository }}"
-          TAG="v${SFCGAL_VERSION}"
 
           cat <<EOF
 
           ════════════════════════════════════════════════════════════════════
+          Tag: ${TAG}
           Add these binaryTarget entries to your Package.swift:
           ════════════════════════════════════════════════════════════════════
 

--- a/.github/workflows/build-xcframeworks.yml
+++ b/.github/workflows/build-xcframeworks.yml
@@ -112,9 +112,9 @@ jobs:
               echo "  $(basename "$lib"): $(lipo -info "$lib" 2>&1)"
             done
 
-            # Check module maps
+            # Only SFCGAL should have module maps (GMP/MPFR are link-only)
             modulemap_count=$(find "$fw_path" -name "module.modulemap" | wc -l | tr -d ' ')
-            if [ "$modulemap_count" -lt 2 ]; then
+            if [ "$fw" = "SFCGAL" ] && [ "$modulemap_count" -lt 2 ]; then
               echo "ERROR: Expected at least 2 module maps in ${fw}.xcframework, found $modulemap_count"
               exit 1
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
           swift-version: "6.2"
           skip-verify-signature: true
 
+      - name: Install SFCGAL (macOS)
+        if: runner.os == 'macOS'
+        run: brew install sfcgal
+
+      - name: Install SFCGAL (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libsfcgal-dev
+
       - name: Swift version
         run: swift --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: swift-actions/setup-swift@v3
         with:
-          swift-version: "6.2"
+          swift-version: "6.2.4"
           skip-verify-signature: true
 
       - name: Install SFCGAL
@@ -40,16 +40,27 @@ jobs:
   test-linux:
     name: Swift on Linux
     runs-on: ubuntu-latest
+    # Ubuntu apt ships an older SFCGAL (1.5.x). This job will fail the
+    # compile-time version check until a PPA or newer distro provides 2.2.0.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
       - uses: swift-actions/setup-swift@v3
         with:
-          swift-version: "6.2"
+          swift-version: "6.2.4"
           skip-verify-signature: true
 
       - name: Install SFCGAL
         run: sudo apt-get update && sudo apt-get install -y libsfcgal-dev
+
+      - name: Check SFCGAL version
+        run: |
+          INSTALLED=$(pkg-config --modversion sfcgal 2>/dev/null || echo "unknown")
+          echo "Installed: $INSTALLED (required: 2.2.0)"
+          if [ "$INSTALLED" != "2.2.0" ]; then
+            echo "::warning::SFCGAL version mismatch — build will likely fail"
+          fi
 
       - name: Build
         run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,7 @@ jobs:
 
       - name: Install CGAL dependencies via vcpkg
         run: |
-          vcpkg install yasm-tool:x86-windows
-          vcpkg install cgal:x64-windows
-        env:
-          VCPKG_DEFAULT_TRIPLET: x64-windows
+          vcpkg install cgal:x64-windows boost-serialization:x64-windows
 
       - name: Cache SFCGAL build
         id: cache-sfcgal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,8 @@ jobs:
   test-linux:
     name: Swift on Linux
     runs-on: ubuntu-latest
-    # Ubuntu apt ships an older SFCGAL (1.5.x). This job will fail the
-    # compile-time version check until a PPA or newer distro provides 2.2.0.
-    continue-on-error: true
+    env:
+      SFCGAL_VERSION: "2.2.0"
     steps:
       - uses: actions/checkout@v4
 
@@ -51,19 +50,57 @@ jobs:
           swift-version: "6.2.4"
           skip-verify-signature: true
 
-      - name: Install SFCGAL
-        run: sudo apt-get update && sudo apt-get install -y libsfcgal-dev
-
-      - name: Check SFCGAL version
+      - name: Install SFCGAL build dependencies
         run: |
-          INSTALLED=$(pkg-config --modversion sfcgal 2>/dev/null || echo "unknown")
-          echo "Installed: $INSTALLED (required: 2.2.0)"
-          if [ "$INSTALLED" != "2.2.0" ]; then
-            echo "::warning::SFCGAL version mismatch — build will likely fail"
-          fi
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            libcgal-dev \
+            libboost-serialization-dev \
+            libgmp-dev \
+            libmpfr-dev \
+            pkg-config
+
+      - name: Cache SFCGAL build
+        id: cache-sfcgal
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/sfcgal
+          key: sfcgal-${{ env.SFCGAL_VERSION }}-ubuntu-${{ runner.arch }}
+
+      - name: Build SFCGAL from source
+        if: steps.cache-sfcgal.outputs.cache-hit != 'true'
+        run: |
+          curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v${SFCGAL_VERSION}/SFCGAL-v${SFCGAL_VERSION}.tar.gz" | tar xz
+          cd SFCGAL-v${SFCGAL_VERSION}
+          cmake -B build \
+            -DCMAKE_INSTALL_PREFIX=/usr/local/sfcgal \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSFCGAL_BUILD_TESTS=OFF \
+            -DSFCGAL_BUILD_EXAMPLES=OFF \
+            -DSFCGAL_BUILD_BENCH=OFF
+          cmake --build build --parallel $(nproc)
+          sudo cmake --install build
+
+      - name: Install cached SFCGAL
+        if: steps.cache-sfcgal.outputs.cache-hit == 'true'
+        run: |
+          sudo cp -a /usr/local/sfcgal/. /usr/local/
+
+      - name: Verify SFCGAL version
+        run: |
+          export PKG_CONFIG_PATH="/usr/local/sfcgal/lib/pkgconfig:$PKG_CONFIG_PATH"
+          INSTALLED=$(pkg-config --modversion sfcgal)
+          echo "Installed: $INSTALLED (required: $SFCGAL_VERSION)"
+          [ "$INSTALLED" = "$SFCGAL_VERSION" ] || { echo "::error::Version mismatch"; exit 1; }
 
       - name: Build
-        run: swift build
+        run: |
+          export PKG_CONFIG_PATH="/usr/local/sfcgal/lib/pkgconfig:$PKG_CONFIG_PATH"
+          swift build
 
       - name: Run tests
-        run: swift test
+        run: |
+          export PKG_CONFIG_PATH="/usr/local/sfcgal/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export LD_LIBRARY_PATH="/usr/local/sfcgal/lib:$LD_LIBRARY_PATH"
+          swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,12 @@ jobs:
         run: |
           :: Bypass pkg-config on Windows — SPM's built-in parser can't handle
           :: the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
-          :: Use the LIB env var (native to MSVC/lld-link) for the library
-          :: search path, and INCLUDE/-Xcc -I for headers. The modulemap's
-          :: link "SFCGAL" directive handles actually linking SFCGAL.lib.
+          :: We need vcvars64 to populate the MSVC CRT LIB/INCLUDE paths
+          :: (Swift needs them to compile the Package.swift manifest). Then
+          :: we PREPEND our SFCGAL + vcpkg paths so lld-link can find
+          :: SFCGAL.lib and transitive deps. The modulemap's link "SFCGAL"
+          :: directive handles actually linking SFCGAL.lib.
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
           swift build -Xcc -IC:/sfcgal/include
@@ -113,6 +116,7 @@ jobs:
         run: |
           :: Add SFCGAL + vcpkg DLL dirs to PATH so the test binary can load
           :: SFCGAL.dll and its dependencies (boost, mpfr, gmp) at runtime.
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set "PATH=C:\sfcgal\bin;C:\vcpkg\installed\x64-windows\bin;%PATH%"
           set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,9 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: Swift on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+  test-macos:
+    name: Swift on macOS
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -20,16 +16,40 @@ jobs:
           swift-version: "6.2"
           skip-verify-signature: true
 
-      - name: Install SFCGAL (macOS)
-        if: runner.os == 'macOS'
+      - name: Install SFCGAL
         run: brew install sfcgal
 
-      - name: Install SFCGAL (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libsfcgal-dev
+      - name: Build
+        run: swift build
 
-      - name: Swift version
-        run: swift --version
+      - name: Run tests
+        run: swift test
+
+  test-ios:
+    name: Swift on iOS Simulator
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build (iOS Simulator)
+        run: |
+          xcodebuild build \
+            -scheme SwiftSFCGAL \
+            -destination 'platform=iOS Simulator,name=iPhone 16'
+
+  test-linux:
+    name: Swift on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: swift-actions/setup-swift@v3
+        with:
+          swift-version: "6.2"
+          skip-verify-signature: true
+
+      - name: Install SFCGAL
+        run: sudo apt-get update && sudo apt-get install -y libsfcgal-dev
 
       - name: Build
         run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
 
       - uses: swift-actions/setup-swift@v3
         with:
-          swift-version: "6.2.4"
-          skip-verify-signature: true
+          swift-version: "6"
 
       - name: Install SFCGAL
         run: brew install sfcgal
@@ -62,8 +61,7 @@ jobs:
 
       - uses: swift-actions/setup-swift@v3
         with:
-          swift-version: "6.2.4"
-          skip-verify-signature: true
+          swift-version: "6"
 
       - name: Install SFCGAL build dependencies
         run: |
@@ -78,7 +76,7 @@ jobs:
 
       - name: Cache SFCGAL build
         id: cache-sfcgal
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.SFCGAL_PREFIX }}
           key: sfcgal-${{ env.SFCGAL_VERSION }}-ubuntu-${{ runner.arch }}
@@ -127,14 +125,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: compnerd/gha-setup-swift@main
+      - uses: swift-actions/setup-swift@v3
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          swift-version: "6"
 
       - name: Cache SFCGAL build
         id: cache-sfcgal
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.SFCGAL_PREFIX }}
           # Bump the suffix to invalidate whenever the build recipe changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: swift-actions/setup-swift@v3
-        with:
-          swift-version: "6"
+      # macOS runners ship Xcode with Swift pre-installed. No setup
+      # action needed — just use whatever the runner provides.
+      - name: Swift version
+        run: swift --version
 
       - name: Install SFCGAL
         run: brew install sfcgal
@@ -61,7 +62,7 @@ jobs:
 
       - uses: swift-actions/setup-swift@v3
         with:
-          swift-version: "6"
+          swift-version: "6.1"
 
       - name: Install SFCGAL build dependencies
         run: |
@@ -125,9 +126,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: swift-actions/setup-swift@v3
+      # swift-actions/setup-swift@v3 does not support Windows yet.
+      # compnerd/gha-setup-swift is maintained by Saleem Abdulrasool
+      # (Swift Core Team member and Windows release manager).
+      - uses: compnerd/gha-setup-swift@main
         with:
-          swift-version: "6"
+          swift-version: swift-6.1-release
+          swift-build: 6.1-RELEASE
+
+      - name: Swift version
+        shell: bash
+        run: swift --version
 
       - name: Cache SFCGAL build
         id: cache-sfcgal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,19 @@ jobs:
 
       - name: Build SFCGAL from source
         if: steps.cache-sfcgal.outputs.cache-hit != 'true'
+        shell: cmd
         run: |
-          curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v${SFCGAL_VERSION}/SFCGAL-v${SFCGAL_VERSION}.tar.gz" | tar xz
-          cd SFCGAL-v${SFCGAL_VERSION}
-          cmake -B build -G Ninja \
-            -DCMAKE_INSTALL_PREFIX=C:/sfcgal \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-            -DSFCGAL_BUILD_TESTS=OFF \
-            -DSFCGAL_BUILD_EXAMPLES=OFF \
+          curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v%SFCGAL_VERSION%/SFCGAL-v%SFCGAL_VERSION%.tar.gz" | tar xz
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cd SFCGAL-v%SFCGAL_VERSION%
+          cmake -B build -G Ninja ^
+            -DCMAKE_C_COMPILER=cl ^
+            -DCMAKE_CXX_COMPILER=cl ^
+            -DCMAKE_INSTALL_PREFIX=C:/sfcgal ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
+            -DSFCGAL_BUILD_TESTS=OFF ^
+            -DSFCGAL_BUILD_EXAMPLES=OFF ^
             -DSFCGAL_BUILD_BENCH=OFF
           cmake --build build --parallel
           cmake --install build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: swift-actions/setup-swift@v3
+      - uses: compnerd/gha-setup-swift@main
         with:
-          swift-version: "6.1"
-          skip-verify-signature: true
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
+
+      - name: Swift version
+        run: swift --version
 
       - name: Install CGAL dependencies via vcpkg
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,17 @@ jobs:
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
           swift build -Xcc -IC:/sfcgal/include
 
+      - name: Inspect DLL dependencies
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          echo === SFCGAL.dll direct dependencies ===
+          dumpbin /DEPENDENTS C:\sfcgal\bin\SFCGAL.dll
+          echo === DLLs in C:\sfcgal\bin ===
+          dir /B C:\sfcgal\bin\*.dll
+          echo === DLLs in C:\vcpkg\installed\x64-windows\bin ===
+          dir /B C:\vcpkg\installed\x64-windows\bin\*.dll
+
       - name: Run tests
         shell: cmd
         run: |
@@ -120,7 +131,16 @@ jobs:
           set "PATH=C:\sfcgal\bin;C:\vcpkg\installed\x64-windows\bin;%PATH%"
           set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
-          swift test -Xcc -IC:/sfcgal/include
+          swift test -Xcc -IC:/sfcgal/include -v || (
+            echo === swift test failed; trying to run xctest binary directly ===
+            dir /S /B .build\*.xctest
+            for /r .build %%F in (*.xctest) do (
+              echo Running: %%F
+              "%%F"
+              echo Exit code: !errorlevel!
+            )
+            exit /b 1
+          )
 
   test-linux:
     name: Swift on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,19 +100,22 @@ jobs:
         run: |
           # Bypass pkg-config on Windows — SPM's built-in parser can't handle
           # the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
-          # Pass include/library paths and link flags directly instead.
+          # Pass include/library paths directly. The modulemap's link "SFCGAL"
+          # directive handles linking; lld-link ignores GNU-style -lSFCGAL.
           swift build \
             -Xcc -IC:/sfcgal/include \
-            -Xlinker -LC:/sfcgal/lib \
-            -Xlinker -lSFCGAL
+            -Xlinker -LIBPATH:C:/sfcgal/lib \
+            -Xlinker -LIBPATH:C:/vcpkg/installed/x64-windows/lib
 
       - name: Run tests
         run: |
-          export PATH="C:/sfcgal/bin:$PATH"
+          # Add SFCGAL + vcpkg DLL dirs to PATH so the test binary can load
+          # SFCGAL.dll and its dependencies (boost, mpfr, gmp) at runtime.
+          export PATH="C:/sfcgal/bin:/c/vcpkg/installed/x64-windows/bin:$PATH"
           swift test \
             -Xcc -IC:/sfcgal/include \
-            -Xlinker -LC:/sfcgal/lib \
-            -Xlinker -lSFCGAL
+            -Xlinker -LIBPATH:C:/sfcgal/lib \
+            -Xlinker -LIBPATH:C:/vcpkg/installed/x64-windows/lib
 
   test-linux:
     name: Swift on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,36 +56,17 @@ jobs:
       - name: Swift version
         run: swift --version
 
-      - name: Install CGAL dependencies via vcpkg
-        id: vcpkg-install
-        shell: cmd
-        run: |
-          vcpkg install cgal:x64-windows boost-serialization:x64-windows
-          :: Capture installed boost version so SFCGAL cache is invalidated
-          :: whenever vcpkg's baseline moves (prevents DLL version mismatch
-          :: between SFCGAL.dll and the boost DLLs on PATH at runtime).
-          for /f "delims=" %%F in ('dir /b C:\vcpkg\installed\x64-windows\bin\boost_serialization-*.dll') do @echo boost-dll=%%F>> %GITHUB_OUTPUT%
-
       - name: Cache SFCGAL build
         id: cache-sfcgal
         uses: actions/cache@v4
         with:
           path: C:/sfcgal
-          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}-${{ steps.vcpkg-install.outputs.boost-dll }}
+          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}-v3-bundled
 
       - name: Build SFCGAL from source
         if: steps.cache-sfcgal.outputs.cache-hit != 'true'
         shell: cmd
         run: |
-          :: GitHub's Windows runner ships pre-installed Boost (e.g. 1.86 at
-          :: C:\local\boost_1_86_0) which CMake's FindBoost picks up via
-          :: BOOST_ROOT* env vars, overriding our vcpkg-provided Boost and
-          :: causing DLL-version mismatches at runtime. Clear them so only
-          :: vcpkg's Boost is visible to CMake.
-          set "BOOST_ROOT="
-          set "BOOST_INCLUDEDIR="
-          set "BOOST_LIBRARYDIR="
-          for /f "delims==" %%V in ('set BOOST_ROOT_ 2^>nul') do set "%%V="
           curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v%SFCGAL_VERSION%/SFCGAL-v%SFCGAL_VERSION%.tar.gz" | tar xz
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd SFCGAL-v%SFCGAL_VERSION%
@@ -95,13 +76,16 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=C:/sfcgal ^
             -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
-            -DBoost_NO_BOOST_CMAKE=OFF ^
-            -DBoost_NO_SYSTEM_PATHS=ON ^
             -DSFCGAL_BUILD_TESTS=OFF ^
             -DSFCGAL_BUILD_EXAMPLES=OFF ^
             -DSFCGAL_BUILD_BENCH=OFF
           cmake --build build --parallel
           cmake --install build
+          :: SFCGAL's vcpkg.json uses manifest mode with a pinned baseline
+          :: (Boost 1.86) that differs from the global vcpkg install (1.90).
+          :: Copy the DLLs SFCGAL actually linked against into C:\sfcgal\bin
+          :: so they're discoverable at runtime from a single directory.
+          copy /Y build\vcpkg_installed\x64-windows\bin\*.dll C:\sfcgal\bin\
 
       - name: Verify SFCGAL installation
         run: |
@@ -119,12 +103,11 @@ jobs:
           :: Bypass pkg-config on Windows — SPM's built-in parser can't handle
           :: the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
           :: We need vcvars64 to populate the MSVC CRT LIB/INCLUDE paths
-          :: (Swift needs them to compile the Package.swift manifest). Then
-          :: we PREPEND our SFCGAL + vcpkg paths so lld-link can find
-          :: SFCGAL.lib and transitive deps. The modulemap's link "SFCGAL"
-          :: directive handles actually linking SFCGAL.lib.
+          :: (Swift needs them to compile the Package.swift manifest), then
+          :: prepend SFCGAL's include/lib so lld-link can find SFCGAL.lib.
+          :: The modulemap's link "SFCGAL" directive handles the actual link.
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
+          set "LIB=C:\sfcgal\lib;%LIB%"
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
           swift build -Xcc -IC:/sfcgal/include
 
@@ -138,11 +121,11 @@ jobs:
       - name: Run tests
         shell: cmd
         run: |
-          :: Add SFCGAL + vcpkg DLL dirs to PATH so the test binary can load
-          :: SFCGAL.dll and its dependencies (boost, mpfr, gmp) at runtime.
+          :: Add SFCGAL bin to PATH so the test binary can load SFCGAL.dll
+          :: and its bundled dependencies (boost, mpfr, gmp) at runtime.
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          set "PATH=C:\sfcgal\bin;C:\vcpkg\installed\x64-windows\bin;%PATH%"
-          set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
+          set "PATH=C:\sfcgal\bin;%PATH%"
+          set "LIB=C:\sfcgal\lib;%LIB%"
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
           swift test -Xcc -IC:/sfcgal/include
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,18 @@ on:
   push:
   pull_request:
 
+env:
+  # Single source of truth for the pinned SFCGAL version. Must match
+  # SWIFTSFCGAL_REQUIRED_VERSION in Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
+  # (enforced at compile time via static_assert in version_check.cc).
+  SFCGAL_VERSION: "2.2.0"
+
 jobs:
   test-macos:
     name: Swift on macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: swift-actions/setup-swift@v3
         with:
@@ -18,6 +24,15 @@ jobs:
 
       - name: Install SFCGAL
         run: brew install sfcgal
+
+      - name: Verify SFCGAL version
+        run: |
+          INSTALLED=$(pkg-config --modversion sfcgal)
+          echo "Installed: $INSTALLED (required: $SFCGAL_VERSION)"
+          [ "$INSTALLED" = "$SFCGAL_VERSION" ] || {
+            echo "::error::SFCGAL version mismatch: expected $SFCGAL_VERSION, got $INSTALLED"
+            exit 1
+          }
 
       - name: Build
         run: swift build
@@ -29,7 +44,7 @@ jobs:
     name: Swift on iOS Simulator
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build (iOS Simulator)
         run: |
@@ -37,105 +52,13 @@ jobs:
             -scheme SwiftSFCGAL \
             -destination 'generic/platform=iOS Simulator'
 
-  test-windows:
-    name: Swift on Windows
-    runs-on: windows-latest
-    env:
-      SFCGAL_VERSION: "2.2.0"
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: compnerd/gha-setup-swift@main
-        with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
-
-      - name: Swift version
-        run: swift --version
-
-      - name: Cache SFCGAL build
-        id: cache-sfcgal
-        uses: actions/cache@v4
-        with:
-          path: C:/sfcgal
-          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}-v3-bundled
-
-      - name: Build SFCGAL from source
-        if: steps.cache-sfcgal.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v%SFCGAL_VERSION%/SFCGAL-v%SFCGAL_VERSION%.tar.gz" | tar xz
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cd SFCGAL-v%SFCGAL_VERSION%
-          cmake -B build -G Ninja ^
-            -DCMAKE_C_COMPILER=cl ^
-            -DCMAKE_CXX_COMPILER=cl ^
-            -DCMAKE_INSTALL_PREFIX=C:/sfcgal ^
-            -DCMAKE_BUILD_TYPE=Release ^
-            -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
-            -DSFCGAL_BUILD_TESTS=OFF ^
-            -DSFCGAL_BUILD_EXAMPLES=OFF ^
-            -DSFCGAL_BUILD_BENCH=OFF
-          cmake --build build --parallel
-          cmake --install build
-          :: SFCGAL's vcpkg.json uses manifest mode with a pinned baseline
-          :: (Boost 1.86) that differs from the global vcpkg install (1.90).
-          :: Copy the DLLs SFCGAL actually linked against into C:\sfcgal\bin
-          :: so they're discoverable at runtime from a single directory.
-          copy /Y build\vcpkg_installed\x64-windows\bin\*.dll C:\sfcgal\bin\
-
-      - name: Verify SFCGAL installation
-        run: |
-          echo "=== Checking SFCGAL headers ==="
-          ls C:/sfcgal/include/SFCGAL/version.h
-          echo "=== Checking SFCGAL libraries ==="
-          ls C:/sfcgal/lib/SFCGAL* || ls C:/sfcgal/lib/libSFCGAL* || true
-          ls C:/sfcgal/lib/*.lib || true
-          echo "=== Checking SFCGAL binaries ==="
-          ls C:/sfcgal/bin/*.dll || true
-
-      - name: Build
-        shell: cmd
-        run: |
-          :: Bypass pkg-config on Windows — SPM's built-in parser can't handle
-          :: the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
-          :: We need vcvars64 to populate the MSVC CRT LIB/INCLUDE paths
-          :: (Swift needs them to compile the Package.swift manifest), then
-          :: prepend SFCGAL's include/lib so lld-link can find SFCGAL.lib.
-          :: The modulemap's link "SFCGAL" directive handles the actual link.
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          set "LIB=C:\sfcgal\lib;%LIB%"
-          set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
-          swift build -Xcc -IC:/sfcgal/include
-
-      - name: Verify DLL dependencies match
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          echo === SFCGAL.dll direct dependencies ===
-          dumpbin /DEPENDENTS C:\sfcgal\bin\SFCGAL.dll
-
-      - name: Run tests
-        shell: cmd
-        run: |
-          :: Add SFCGAL bin to PATH so the test binary can load SFCGAL.dll
-          :: and its bundled dependencies (boost, mpfr, gmp) at runtime.
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          set "PATH=C:\sfcgal\bin;%PATH%"
-          set "LIB=C:\sfcgal\lib;%LIB%"
-          set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
-          swift test -Xcc -IC:/sfcgal/include
-
   test-linux:
     name: Swift on Linux
     runs-on: ubuntu-latest
     env:
-      SFCGAL_VERSION: "2.2.0"
+      SFCGAL_PREFIX: /usr/local/sfcgal
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: swift-actions/setup-swift@v3
         with:
@@ -157,7 +80,7 @@ jobs:
         id: cache-sfcgal
         uses: actions/cache@v4
         with:
-          path: /usr/local/sfcgal
+          path: ${{ env.SFCGAL_PREFIX }}
           key: sfcgal-${{ env.SFCGAL_VERSION }}-ubuntu-${{ runner.arch }}
 
       - name: Build SFCGAL from source
@@ -166,7 +89,7 @@ jobs:
           curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v${SFCGAL_VERSION}/SFCGAL-v${SFCGAL_VERSION}.tar.gz" | tar xz
           cd SFCGAL-v${SFCGAL_VERSION}
           cmake -B build \
-            -DCMAKE_INSTALL_PREFIX=/usr/local/sfcgal \
+            -DCMAKE_INSTALL_PREFIX=${SFCGAL_PREFIX} \
             -DCMAKE_BUILD_TYPE=Release \
             -DSFCGAL_BUILD_TESTS=OFF \
             -DSFCGAL_BUILD_EXAMPLES=OFF \
@@ -174,25 +97,105 @@ jobs:
           cmake --build build --parallel $(nproc)
           sudo cmake --install build
 
-      - name: Install cached SFCGAL
-        if: steps.cache-sfcgal.outputs.cache-hit == 'true'
-        run: |
-          sudo cp -a /usr/local/sfcgal/. /usr/local/
-
       - name: Verify SFCGAL version
         run: |
-          export PKG_CONFIG_PATH="/usr/local/sfcgal/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export PKG_CONFIG_PATH="${SFCGAL_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH"
           INSTALLED=$(pkg-config --modversion sfcgal)
           echo "Installed: $INSTALLED (required: $SFCGAL_VERSION)"
-          [ "$INSTALLED" = "$SFCGAL_VERSION" ] || { echo "::error::Version mismatch"; exit 1; }
+          [ "$INSTALLED" = "$SFCGAL_VERSION" ] || {
+            echo "::error::SFCGAL version mismatch: expected $SFCGAL_VERSION, got $INSTALLED"
+            exit 1
+          }
 
       - name: Build
         run: |
-          export PKG_CONFIG_PATH="/usr/local/sfcgal/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export PKG_CONFIG_PATH="${SFCGAL_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH"
           swift build
 
       - name: Run tests
         run: |
-          export PKG_CONFIG_PATH="/usr/local/sfcgal/lib/pkgconfig:$PKG_CONFIG_PATH"
-          export LD_LIBRARY_PATH="/usr/local/sfcgal/lib:$LD_LIBRARY_PATH"
+          export PKG_CONFIG_PATH="${SFCGAL_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export LD_LIBRARY_PATH="${SFCGAL_PREFIX}/lib:$LD_LIBRARY_PATH"
           swift test
+
+  test-windows:
+    name: Swift on Windows
+    runs-on: windows-latest
+    env:
+      SFCGAL_PREFIX: C:/sfcgal
+      VCVARS: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
+
+      - name: Cache SFCGAL build
+        id: cache-sfcgal
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SFCGAL_PREFIX }}
+          # Bump the suffix to invalidate whenever the build recipe changes
+          # (e.g. a new vcpkg baseline changes bundled DLL names).
+          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}-v3
+
+      - name: Build SFCGAL from source
+        if: steps.cache-sfcgal.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v%SFCGAL_VERSION%/SFCGAL-v%SFCGAL_VERSION%.tar.gz" | tar xz
+          call "%VCVARS%"
+          cd SFCGAL-v%SFCGAL_VERSION%
+          cmake -B build -G Ninja ^
+            -DCMAKE_C_COMPILER=cl ^
+            -DCMAKE_CXX_COMPILER=cl ^
+            -DCMAKE_INSTALL_PREFIX=%SFCGAL_PREFIX% ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
+            -DSFCGAL_BUILD_TESTS=OFF ^
+            -DSFCGAL_BUILD_EXAMPLES=OFF ^
+            -DSFCGAL_BUILD_BENCH=OFF
+          cmake --build build --parallel
+          cmake --install build
+          :: SFCGAL uses vcpkg manifest mode (its own vcpkg.json pins Boost 1.86),
+          :: so its build creates a local vcpkg_installed tree that SFCGAL.dll
+          :: links against. Bundle those DLLs next to SFCGAL.dll so the loader
+          :: can resolve them from a single directory at runtime.
+          copy /Y build\vcpkg_installed\x64-windows\bin\*.dll %SFCGAL_PREFIX:/=\%\bin\
+
+      - name: Verify SFCGAL version
+        shell: bash
+        run: |
+          HEADER="${SFCGAL_PREFIX}/include/SFCGAL/version.h"
+          INSTALLED=$(grep -Po '#define SFCGAL_VERSION "\K[^"]+' "$HEADER")
+          echo "Installed: $INSTALLED (required: $SFCGAL_VERSION)"
+          [ "$INSTALLED" = "$SFCGAL_VERSION" ] || {
+            echo "::error::SFCGAL version mismatch: expected $SFCGAL_VERSION, got $INSTALLED"
+            exit 1
+          }
+
+      - name: Build
+        shell: cmd
+        run: |
+          :: Bypass pkg-config on Windows — SPM's built-in parser can't handle
+          :: the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
+          :: Pass paths through MSVC-native LIB/INCLUDE env vars (populated by
+          :: vcvars64 with MSVC CRT paths, then prepended with SFCGAL's dirs).
+          :: The modulemap's link "SFCGAL" handles the actual link.
+          call "%VCVARS%"
+          set "LIB=%SFCGAL_PREFIX:/=\%\lib;%LIB%"
+          set "INCLUDE=%SFCGAL_PREFIX:/=\%\include;%INCLUDE%"
+          swift build -Xcc -I%SFCGAL_PREFIX%/include
+
+      - name: Run tests
+        shell: cmd
+        run: |
+          :: Add SFCGAL bin to PATH so the test binary can load SFCGAL.dll
+          :: and its bundled dependencies (boost, mpfr, gmp) at runtime.
+          call "%VCVARS%"
+          set "PATH=%SFCGAL_PREFIX:/=\%\bin;%PATH%"
+          set "LIB=%SFCGAL_PREFIX:/=\%\lib;%LIB%"
+          set "INCLUDE=%SFCGAL_PREFIX:/=\%\include;%INCLUDE%"
+          swift test -Xcc -I%SFCGAL_PREFIX%/include

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:/sfcgal
-          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}
+          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}-v2
 
       - name: Build SFCGAL from source
         if: steps.cache-sfcgal.outputs.cache-hit != 'true'
@@ -86,30 +86,33 @@ jobs:
           cmake --build build --parallel
           cmake --install build
 
-      - name: Fix pkg-config file
+      - name: Verify SFCGAL installation
         run: |
-          # SFCGAL's CMake generates an empty prefix= in sfcgal.pc on Windows.
-          # Patch it so SPM's built-in pkg-config parser can resolve paths.
-          sed -i 's|^prefix=$|prefix=C:/sfcgal|' C:/sfcgal/lib/pkgconfig/sfcgal.pc
-          echo "--- sfcgal.pc ---"
-          cat C:/sfcgal/lib/pkgconfig/sfcgal.pc
-
-      - name: Verify SFCGAL version
-        run: |
-          export PKG_CONFIG_PATH="C:/sfcgal/lib/pkgconfig"
-          pkg-config --modversion sfcgal || echo "pkg-config binary not available (SPM has built-in parser)"
+          echo "=== Checking SFCGAL headers ==="
           ls C:/sfcgal/include/SFCGAL/version.h
+          echo "=== Checking SFCGAL libraries ==="
+          ls C:/sfcgal/lib/SFCGAL* || ls C:/sfcgal/lib/libSFCGAL* || true
+          ls C:/sfcgal/lib/*.lib || true
+          echo "=== Checking SFCGAL binaries ==="
+          ls C:/sfcgal/bin/*.dll || true
 
       - name: Build
         run: |
-          export PKG_CONFIG_PATH="C:/sfcgal/lib/pkgconfig"
-          swift build
+          # Bypass pkg-config on Windows — SPM's built-in parser can't handle
+          # the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
+          # Pass include/library paths and link flags directly instead.
+          swift build \
+            -Xcc -IC:/sfcgal/include \
+            -Xlinker -LC:/sfcgal/lib \
+            -Xlinker -lSFCGAL
 
       - name: Run tests
         run: |
-          export PKG_CONFIG_PATH="C:/sfcgal/lib/pkgconfig"
           export PATH="C:/sfcgal/bin:$PATH"
-          swift test
+          swift test \
+            -Xcc -IC:/sfcgal/include \
+            -Xlinker -LC:/sfcgal/lib \
+            -Xlinker -lSFCGAL
 
   test-linux:
     name: Swift on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         shell: bash
         run: |
           HEADER="${SFCGAL_PREFIX}/include/SFCGAL/version.h"
-          INSTALLED=$(grep -Po '#define SFCGAL_VERSION "\K[^"]+' "$HEADER")
+          INSTALLED=$(sed -n 's/.*#define SFCGAL_VERSION "\([^"]*\)".*/\1/p' "$HEADER")
           echo "Installed: $INSTALLED (required: $SFCGAL_VERSION)"
           [ "$INSTALLED" = "$SFCGAL_VERSION" ] || {
             echo "::error::SFCGAL version mismatch: expected $SFCGAL_VERSION, got $INSTALLED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,19 @@ jobs:
           cmake --build build --parallel
           cmake --install build
 
+      - name: Fix pkg-config file
+        run: |
+          # SFCGAL's CMake generates an empty prefix= in sfcgal.pc on Windows.
+          # Patch it so SPM's built-in pkg-config parser can resolve paths.
+          sed -i 's|^prefix=$|prefix=C:/sfcgal|' C:/sfcgal/lib/pkgconfig/sfcgal.pc
+          echo "--- sfcgal.pc ---"
+          cat C:/sfcgal/lib/pkgconfig/sfcgal.pc
+
       - name: Verify SFCGAL version
         run: |
           export PKG_CONFIG_PATH="C:/sfcgal/lib/pkgconfig"
-          pkg-config --modversion sfcgal || echo "pkg-config not found, checking install..."
-          ls -la C:/sfcgal/lib/ || true
-          ls -la C:/sfcgal/include/SFCGAL/ || true
+          pkg-config --modversion sfcgal || echo "pkg-config binary not available (SPM has built-in parser)"
+          ls C:/sfcgal/include/SFCGAL/version.h
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           xcodebuild build \
             -scheme SwiftSFCGAL \
-            -destination 'platform=iOS Simulator,name=iPhone 16'
+            -destination 'generic/platform=iOS Simulator'
 
   test-linux:
     name: Swift on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
         if: steps.cache-sfcgal.outputs.cache-hit != 'true'
         shell: cmd
         run: |
+          :: GitHub's Windows runner ships pre-installed Boost (e.g. 1.86 at
+          :: C:\local\boost_1_86_0) which CMake's FindBoost picks up via
+          :: BOOST_ROOT* env vars, overriding our vcpkg-provided Boost and
+          :: causing DLL-version mismatches at runtime. Clear them so only
+          :: vcpkg's Boost is visible to CMake.
+          set "BOOST_ROOT="
+          set "BOOST_INCLUDEDIR="
+          set "BOOST_LIBRARYDIR="
+          for /f "delims==" %%V in ('set BOOST_ROOT_ 2^>nul') do set "%%V="
           curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v%SFCGAL_VERSION%/SFCGAL-v%SFCGAL_VERSION%.tar.gz" | tar xz
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd SFCGAL-v%SFCGAL_VERSION%
@@ -86,6 +95,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=C:/sfcgal ^
             -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
+            -DBoost_NO_BOOST_CMAKE=OFF ^
+            -DBoost_NO_SYSTEM_PATHS=ON ^
             -DSFCGAL_BUILD_TESTS=OFF ^
             -DSFCGAL_BUILD_EXAMPLES=OFF ^
             -DSFCGAL_BUILD_BENCH=OFF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,25 +97,26 @@ jobs:
           ls C:/sfcgal/bin/*.dll || true
 
       - name: Build
+        shell: cmd
         run: |
-          # Bypass pkg-config on Windows — SPM's built-in parser can't handle
-          # the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
-          # Pass include/library paths directly. The modulemap's link "SFCGAL"
-          # directive handles linking; lld-link ignores GNU-style -lSFCGAL.
-          swift build \
-            -Xcc -IC:/sfcgal/include \
-            -Xlinker -LIBPATH:C:/sfcgal/lib \
-            -Xlinker -LIBPATH:C:/vcpkg/installed/x64-windows/lib
+          :: Bypass pkg-config on Windows — SPM's built-in parser can't handle
+          :: the empty prefix= that SFCGAL's CMake generates in sfcgal.pc.
+          :: Use the LIB env var (native to MSVC/lld-link) for the library
+          :: search path, and INCLUDE/-Xcc -I for headers. The modulemap's
+          :: link "SFCGAL" directive handles actually linking SFCGAL.lib.
+          set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
+          set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
+          swift build -Xcc -IC:/sfcgal/include
 
       - name: Run tests
+        shell: cmd
         run: |
-          # Add SFCGAL + vcpkg DLL dirs to PATH so the test binary can load
-          # SFCGAL.dll and its dependencies (boost, mpfr, gmp) at runtime.
-          export PATH="C:/sfcgal/bin:/c/vcpkg/installed/x64-windows/bin:$PATH"
-          swift test \
-            -Xcc -IC:/sfcgal/include \
-            -Xlinker -LIBPATH:C:/sfcgal/lib \
-            -Xlinker -LIBPATH:C:/vcpkg/installed/x64-windows/lib
+          :: Add SFCGAL + vcpkg DLL dirs to PATH so the test binary can load
+          :: SFCGAL.dll and its dependencies (boost, mpfr, gmp) at runtime.
+          set "PATH=C:\sfcgal\bin;C:\vcpkg\installed\x64-windows\bin;%PATH%"
+          set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
+          set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
+          swift test -Xcc -IC:/sfcgal/include
 
   test-linux:
     name: Swift on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,21 @@ jobs:
         run: swift --version
 
       - name: Install CGAL dependencies via vcpkg
+        id: vcpkg-install
+        shell: cmd
         run: |
           vcpkg install cgal:x64-windows boost-serialization:x64-windows
+          :: Capture installed boost version so SFCGAL cache is invalidated
+          :: whenever vcpkg's baseline moves (prevents DLL version mismatch
+          :: between SFCGAL.dll and the boost DLLs on PATH at runtime).
+          for /f "delims=" %%F in ('dir /b C:\vcpkg\installed\x64-windows\bin\boost_serialization-*.dll') do @echo boost-dll=%%F>> %GITHUB_OUTPUT%
 
       - name: Cache SFCGAL build
         id: cache-sfcgal
         uses: actions/cache@v4
         with:
           path: C:/sfcgal
-          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}-v2
+          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}-${{ steps.vcpkg-install.outputs.boost-dll }}
 
       - name: Build SFCGAL from source
         if: steps.cache-sfcgal.outputs.cache-hit != 'true'
@@ -111,16 +117,12 @@ jobs:
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
           swift build -Xcc -IC:/sfcgal/include
 
-      - name: Inspect DLL dependencies
+      - name: Verify DLL dependencies match
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           echo === SFCGAL.dll direct dependencies ===
           dumpbin /DEPENDENTS C:\sfcgal\bin\SFCGAL.dll
-          echo === DLLs in C:\sfcgal\bin ===
-          dir /B C:\sfcgal\bin\*.dll
-          echo === DLLs in C:\vcpkg\installed\x64-windows\bin ===
-          dir /B C:\vcpkg\installed\x64-windows\bin\*.dll
 
       - name: Run tests
         shell: cmd
@@ -131,16 +133,7 @@ jobs:
           set "PATH=C:\sfcgal\bin;C:\vcpkg\installed\x64-windows\bin;%PATH%"
           set "LIB=C:\sfcgal\lib;C:\vcpkg\installed\x64-windows\lib;%LIB%"
           set "INCLUDE=C:\sfcgal\include;%INCLUDE%"
-          swift test -Xcc -IC:/sfcgal/include -v || (
-            echo === swift test failed; trying to run xctest binary directly ===
-            dir /S /B .build\*.xctest
-            for /r .build %%F in (*.xctest) do (
-              echo Running: %%F
-              "%%F"
-              echo Exit code: !errorlevel!
-            )
-            exit /b 1
-          )
+          swift test -Xcc -IC:/sfcgal/include
 
   test-linux:
     name: Swift on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,69 @@ jobs:
             -scheme SwiftSFCGAL \
             -destination 'generic/platform=iOS Simulator'
 
+  test-windows:
+    name: Swift on Windows
+    runs-on: windows-latest
+    env:
+      SFCGAL_VERSION: "2.2.0"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: swift-actions/setup-swift@v3
+        with:
+          swift-version: "6.1"
+          skip-verify-signature: true
+
+      - name: Install CGAL dependencies via vcpkg
+        run: |
+          vcpkg install yasm-tool:x86-windows
+          vcpkg install cgal:x64-windows
+        env:
+          VCPKG_DEFAULT_TRIPLET: x64-windows
+
+      - name: Cache SFCGAL build
+        id: cache-sfcgal
+        uses: actions/cache@v4
+        with:
+          path: C:/sfcgal
+          key: sfcgal-${{ env.SFCGAL_VERSION }}-windows-${{ runner.arch }}
+
+      - name: Build SFCGAL from source
+        if: steps.cache-sfcgal.outputs.cache-hit != 'true'
+        run: |
+          curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v${SFCGAL_VERSION}/SFCGAL-v${SFCGAL_VERSION}.tar.gz" | tar xz
+          cd SFCGAL-v${SFCGAL_VERSION}
+          cmake -B build -G Ninja \
+            -DCMAKE_INSTALL_PREFIX=C:/sfcgal \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            -DSFCGAL_BUILD_TESTS=OFF \
+            -DSFCGAL_BUILD_EXAMPLES=OFF \
+            -DSFCGAL_BUILD_BENCH=OFF
+          cmake --build build --parallel
+          cmake --install build
+
+      - name: Verify SFCGAL version
+        run: |
+          export PKG_CONFIG_PATH="C:/sfcgal/lib/pkgconfig"
+          pkg-config --modversion sfcgal || echo "pkg-config not found, checking install..."
+          ls -la C:/sfcgal/lib/ || true
+          ls -la C:/sfcgal/include/SFCGAL/ || true
+
+      - name: Build
+        run: |
+          export PKG_CONFIG_PATH="C:/sfcgal/lib/pkgconfig"
+          swift build
+
+      - name: Run tests
+        run: |
+          export PKG_CONFIG_PATH="C:/sfcgal/lib/pkgconfig"
+          export PATH="C:/sfcgal/bin:$PATH"
+          swift test
+
   test-linux:
     name: Swift on Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: swift-actions/setup-swift@v3
         with:
           swift-version: "6.1"
+          skip-verify-signature: true
 
       - name: Install SFCGAL build dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ DerivedData/
 gmp-ios-build/
 mpfr-ios-build/
 sfcgal-ios-build/
+xcframeworks/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+
+# Cross-compilation build artifacts
+gmp-ios-build/
+mpfr-ios-build/
+sfcgal-ios-build/

--- a/Package.swift
+++ b/Package.swift
@@ -53,18 +53,18 @@ let package = Package(
         // ── iOS: prebuilt XCFrameworks (downloaded from GitHub releases) ──
         .binaryTarget(
             name: "CSFCGAL_Binary",
-            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-1/SFCGAL.xcframework.zip",
-            checksum: "1d596bf0cb510005357435f9eefdc332858008f333c74b35ad5dd08be57b8bfe"
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-2/SFCGAL.xcframework.zip",
+            checksum: "29fdf7a187723f7167fe88e5f138becc5c468cafed013586d32e1af1b785a371"
         ),
         .binaryTarget(
             name: "CGMP_Binary",
-            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-1/GMP.xcframework.zip",
-            checksum: "2b3919dae1dcc7ef75e27dc0260d99b16cab331a562e855a40ea86b47ef7527f"
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-2/GMP.xcframework.zip",
+            checksum: "aa48ddd715a1d5a02b81ce392d3347bc743de0eef890cf482e1df45764b8f871"
         ),
         .binaryTarget(
             name: "CMPFR_Binary",
-            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-1/MPFR.xcframework.zip",
-            checksum: "2d58f110d04e9ac7f621c322a65e1cdfa07b2072956b2ced97bc1c685382910a"
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-2/MPFR.xcframework.zip",
+            checksum: "a5f648d4bb87e3f02a5cd0f19d08a7ac9ae7d5ffa082498b4c64d5ba948f3590"
         ),
 
         // ── Tests ──

--- a/Package.swift
+++ b/Package.swift
@@ -53,18 +53,18 @@ let package = Package(
         // ── iOS: prebuilt XCFrameworks (downloaded from GitHub releases) ──
         .binaryTarget(
             name: "CSFCGAL_Binary",
-            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-2/SFCGAL.xcframework.zip",
-            checksum: "29fdf7a187723f7167fe88e5f138becc5c468cafed013586d32e1af1b785a371"
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-3/SFCGAL.xcframework.zip",
+            checksum: "6ac2ce11aa09ebe1117ae82332e14530fb7da7ed49ce6a1631ed2928c3067975"
         ),
         .binaryTarget(
             name: "CGMP_Binary",
-            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-2/GMP.xcframework.zip",
-            checksum: "aa48ddd715a1d5a02b81ce392d3347bc743de0eef890cf482e1df45764b8f871"
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-3/GMP.xcframework.zip",
+            checksum: "125d4b643b4a5691a7f46d71211487e7c90d65a75e136461ce4747eb73e80bbd"
         ),
         .binaryTarget(
             name: "CMPFR_Binary",
-            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-2/MPFR.xcframework.zip",
-            checksum: "a5f648d4bb87e3f02a5cd0f19d08a7ac9ae7d5ffa082498b4c64d5ba948f3590"
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-3/MPFR.xcframework.zip",
+            checksum: "291c0a70b688772328b28404a403d0b2b90a6174914af1741e53a0aba470f7f3"
         ),
 
         // ── Tests ──

--- a/Package.swift
+++ b/Package.swift
@@ -1,26 +1,73 @@
-// swift-tools-version: 6.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(
-    name: "SFCGAL",
+    name: "SwiftSFCGAL",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
-        .library(
-            name: "SFCGAL",
-            targets: ["SFCGAL"]
-        ),
+        .library(name: "SwiftSFCGAL", targets: ["SwiftSFCGAL"]),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
+        // ── The public Swift API ──
         .target(
-            name: "SFCGAL"
+            name: "SwiftSFCGAL",
+            dependencies: [
+                "CSFCGAL_Shim",
+                .target(name: "CSFCGAL_System",
+                    condition: .when(platforms: [.macOS, .linux])),
+                .target(name: "CSFCGAL_Binary",
+                    condition: .when(platforms: [.iOS, .tvOS, .watchOS, .visionOS])),
+                .target(name: "CGMP_Binary",
+                    condition: .when(platforms: [.iOS, .tvOS, .watchOS, .visionOS])),
+                .target(name: "CMPFR_Binary",
+                    condition: .when(platforms: [.iOS, .tvOS, .watchOS, .visionOS])),
+            ]
         ),
-        .testTarget(
-            name: "SFCGALTests",
-            dependencies: ["SFCGAL"]
+
+        // ── C shim layer (cross-platform, compiled from source) ──
+        .target(
+            name: "CSFCGAL_Shim",
+            dependencies: [
+                .target(name: "CSFCGAL_System",
+                    condition: .when(platforms: [.macOS, .linux])),
+                .target(name: "CSFCGAL_Binary",
+                    condition: .when(platforms: [.iOS, .tvOS, .watchOS, .visionOS])),
+            ],
+            path: "Sources/CSFCGAL_Shim",
+            publicHeadersPath: "include"
         ),
+
+        // ── macOS / Linux: use system-installed SFCGAL ──
+        .systemLibrary(
+            name: "CSFCGAL_System",
+            pkgConfig: "sfcgal",
+            providers: [
+                .brew(["sfcgal"]),
+                .apt(["libsfcgal-dev"]),
+            ]
+        ),
+
+        // ── iOS: prebuilt XCFrameworks (downloaded from GitHub releases) ──
+        .binaryTarget(
+            name: "CSFCGAL_Binary",
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-1/SFCGAL.xcframework.zip",
+            checksum: "1d596bf0cb510005357435f9eefdc332858008f333c74b35ad5dd08be57b8bfe"
+        ),
+        .binaryTarget(
+            name: "CGMP_Binary",
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-1/GMP.xcframework.zip",
+            checksum: "2b3919dae1dcc7ef75e27dc0260d99b16cab331a562e855a40ea86b47ef7527f"
+        ),
+        .binaryTarget(
+            name: "CMPFR_Binary",
+            url: "https://github.com/Postert/SFCGAL_SPM/releases/download/v2.2.0-1/MPFR.xcframework.zip",
+            checksum: "2d58f110d04e9ac7f621c322a65e1cdfa07b2072956b2ced97bc1c685382910a"
+        ),
+
+        // ── Tests ──
+        .testTarget(name: "SwiftSFCGALTests", dependencies: ["SwiftSFCGAL"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             dependencies: [
                 "CSFCGAL_Shim",
                 .target(name: "CSFCGAL_System",
-                    condition: .when(platforms: [.macOS, .linux])),
+                    condition: .when(platforms: [.macOS, .linux, .windows])),
                 .target(name: "CSFCGAL_Binary",
                     condition: .when(platforms: [.iOS, .tvOS, .watchOS, .visionOS])),
                 .target(name: "CGMP_Binary",
@@ -32,7 +32,7 @@ let package = Package(
             name: "CSFCGAL_Shim",
             dependencies: [
                 .target(name: "CSFCGAL_System",
-                    condition: .when(platforms: [.macOS, .linux])),
+                    condition: .when(platforms: [.macOS, .linux, .windows])),
                 .target(name: "CSFCGAL_Binary",
                     condition: .when(platforms: [.iOS, .tvOS, .watchOS, .visionOS])),
             ],

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SwiftSFCGAL
 
-A Swift Package wrapping the [SFCGAL](https://sfcgal.gitlab.io/SFCGAL/) computational geometry library for iOS, macOS, and Linux.
+A Swift Package wrapping the [SFCGAL](https://sfcgal.gitlab.io/SFCGAL/) computational geometry library for iOS, macOS, Linux, and Windows.
 
 ## Overview
 
-SwiftSFCGAL provides idiomatic Swift access to SFCGAL's full suite of 2D and 3D computational geometry operations — triangulation, Boolean operations, measurements, straight skeletons, extrusions, and more. It is designed primarily for iOS (ARKit/RealityKit pipelines, CityGML rendering), with macOS and Linux as secondary targets.
+SwiftSFCGAL provides idiomatic Swift access to SFCGAL's full suite of 2D and 3D computational geometry operations — triangulation, Boolean operations, measurements, straight skeletons, extrusions, and more. It is designed primarily for iOS (ARKit/RealityKit pipelines, CityGML rendering), with macOS, Linux, and Windows as secondary targets.
 
 SFCGAL is a C++ library built on top of [CGAL](https://www.cgal.org/) (the Computational Geometry Algorithms Library) that provides ISO 19107:2013 and OGC Simple Features Access 1.2 compliant geometry types and operations. It serves as the geometry backend for PostGIS's 3D spatial functions and is an [OSGeo project](https://www.osgeo.org/projects/sfcgal/).
 
@@ -13,8 +13,20 @@ SFCGAL is a C++ library built on top of [CGAL](https://www.cgal.org/) (the Compu
 | Platform | Toolchain | SFCGAL source |
 |----------|-----------|---------------|
 | macOS    | Xcode 16+ | System library via Homebrew |
-| Linux (Ubuntu/Debian) | [Swift.org toolchain](https://www.swift.org/install/linux/) | System library via apt |
-| iOS / visionOS | Xcode 16+ | Bundled XCFramework |
+| Linux (Ubuntu/Debian) | [Swift.org toolchain](https://www.swift.org/install/linux/) | Built from source (Ubuntu's apt ships an older version) |
+| Windows  | [Swift.org toolchain](https://www.swift.org/install/windows/) + Visual Studio 2022 | Built from source with vcpkg dependencies |
+| iOS / tvOS / watchOS / visionOS | Xcode 16+ | Prebuilt XCFrameworks (downloaded automatically by SPM) |
+
+## Version pinning
+
+SwiftSFCGAL pins an **exact** SFCGAL version (currently **2.2.0**) and enforces this at compile time via a C++ `static_assert` in [`version_check.cc`](Sources/CSFCGAL_Shim/version_check.cc). If the installed SFCGAL version does not match, the build fails with a clear error message. This guarantees that the Swift wrapper, the system library, and the iOS XCFrameworks are always binary-compatible.
+
+The required version is defined in a single place:
+
+```c
+// Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
+#define SWIFTSFCGAL_REQUIRED_VERSION "2.2.0"
+```
 
 ## Usage
 
@@ -22,7 +34,7 @@ Add the package to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/<owner>/SwiftSFCGAL.git", from: "0.1.0")
+    .package(url: "https://github.com/Postert/SFCGAL_SPM.git", from: "0.1.0")
 ]
 ```
 
@@ -37,15 +49,164 @@ Then add `"SwiftSFCGAL"` as a dependency of your target:
 )
 ```
 
+## Development setup
+
+### Prerequisites
+
+| Platform | Swift | Additional tooling |
+|----------|-------|--------------------|
+| macOS | Included with Xcode 16+ | [Homebrew](https://brew.sh/) |
+| Linux | [Swift.org toolchain](https://www.swift.org/install/linux/) (6.1+) | `cmake`, `pkg-config`, C/C++ compiler |
+| Windows | [Swift.org toolchain](https://www.swift.org/install/windows/) (6.1+) | Visual Studio 2022, [vcpkg](https://vcpkg.io/), CMake, Ninja |
+| iOS | Included with Xcode 16+ | None — XCFrameworks are downloaded automatically |
+
+### macOS
+
+SFCGAL is available via Homebrew as a single install:
+
+```bash
+brew install sfcgal
+
+# Verify the installed version matches the one pinned by SwiftSFCGAL (2.2.0):
+pkg-config --modversion sfcgal
+
+# Build and test:
+swift build
+swift test
+```
+
+> **Tip:** You can also open the package in Xcode and build/test from there.
+
+### Linux (Ubuntu / Debian)
+
+Ubuntu's `apt` repositories ship an older SFCGAL (1.5.1 on 24.04 LTS), which does not match the pinned version. You need to build SFCGAL **2.2.0** from source.
+
+**1. Install build dependencies:**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+    cmake \
+    libcgal-dev \
+    libboost-serialization-dev \
+    libgmp-dev \
+    libmpfr-dev \
+    pkg-config
+```
+
+**2. Build and install SFCGAL 2.2.0:**
+
+```bash
+SFCGAL_VERSION=2.2.0
+SFCGAL_PREFIX=/usr/local/sfcgal
+
+curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v${SFCGAL_VERSION}/SFCGAL-v${SFCGAL_VERSION}.tar.gz" | tar xz
+cd SFCGAL-v${SFCGAL_VERSION}
+cmake -B build \
+    -DCMAKE_INSTALL_PREFIX=${SFCGAL_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DSFCGAL_BUILD_TESTS=OFF \
+    -DSFCGAL_BUILD_EXAMPLES=OFF \
+    -DSFCGAL_BUILD_BENCH=OFF
+cmake --build build --parallel $(nproc)
+sudo cmake --install build
+```
+
+**3. Build and test SwiftSFCGAL:**
+
+Since SFCGAL is installed to a custom prefix, you need to tell SPM and the dynamic linker where to find it:
+
+```bash
+export PKG_CONFIG_PATH="${SFCGAL_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH"
+export LD_LIBRARY_PATH="${SFCGAL_PREFIX}/lib:$LD_LIBRARY_PATH"
+
+# Verify:
+pkg-config --modversion sfcgal   # should print 2.2.0
+
+# Build and test:
+swift build
+swift test
+```
+
+### Windows
+
+Windows requires Visual Studio 2022 (for the MSVC toolchain and CRT headers), the [Swift.org toolchain for Windows](https://www.swift.org/install/windows/), and [vcpkg](https://vcpkg.io/) for the transitive C++ dependencies (CGAL, Boost, GMP, MPFR).
+
+**1. Build and install SFCGAL 2.2.0 from source:**
+
+Open a **Developer Command Prompt for VS 2022** (or run `vcvars64.bat` manually) and run:
+
+```cmd
+set SFCGAL_VERSION=2.2.0
+set SFCGAL_PREFIX=C:\sfcgal
+
+curl -sL "https://gitlab.com/sfcgal/SFCGAL/-/archive/v%SFCGAL_VERSION%/SFCGAL-v%SFCGAL_VERSION%.tar.gz" | tar xz
+cd SFCGAL-v%SFCGAL_VERSION%
+
+cmake -B build -G Ninja ^
+    -DCMAKE_C_COMPILER=cl ^
+    -DCMAKE_CXX_COMPILER=cl ^
+    -DCMAKE_INSTALL_PREFIX=%SFCGAL_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake ^
+    -DSFCGAL_BUILD_TESTS=OFF ^
+    -DSFCGAL_BUILD_EXAMPLES=OFF ^
+    -DSFCGAL_BUILD_BENCH=OFF
+cmake --build build --parallel
+cmake --install build
+```
+
+> **Note:** SFCGAL ships its own `vcpkg.json` (manifest mode), so vcpkg automatically downloads and builds the correct versions of CGAL, Boost, GMP, and MPFR during the CMake configure step. No manual `vcpkg install` is needed.
+
+**2. Bundle runtime DLLs:**
+
+SFCGAL's vcpkg manifest pins specific dependency versions (e.g. Boost 1.86) that may differ from a global vcpkg install. Copy the DLLs that SFCGAL was actually linked against into the install directory so the Windows loader can find them at runtime:
+
+```cmd
+copy /Y build\vcpkg_installed\x64-windows\bin\*.dll %SFCGAL_PREFIX%\bin\
+```
+
+**3. Build and test SwiftSFCGAL:**
+
+SPM's built-in pkg-config parser cannot handle the `.pc` file that SFCGAL's CMake generates on Windows (it has an empty `prefix=` variable). Instead, pass paths through the native MSVC environment variables. From a **Developer Command Prompt**:
+
+```cmd
+set "PATH=%SFCGAL_PREFIX%\bin;%PATH%"
+set "LIB=%SFCGAL_PREFIX%\lib;%LIB%"
+set "INCLUDE=%SFCGAL_PREFIX%\include;%INCLUDE%"
+
+swift build -Xcc -I%SFCGAL_PREFIX%/include
+swift test  -Xcc -I%SFCGAL_PREFIX%/include
+```
+
+> **Note:** The `vcvars64.bat` path varies by Visual Studio edition:
+> - **Community:** `C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat`
+> - **Professional:** replace `Community` with `Professional`
+> - **Enterprise:** replace `Community` with `Enterprise`
+
+### iOS / tvOS / watchOS / visionOS
+
+**No setup required.** The prebuilt XCFrameworks (SFCGAL, GMP, MPFR) are hosted on GitHub releases and downloaded automatically by SPM when you add the package. Just add the dependency to your Xcode project or `Package.swift` and build.
+
+To verify the iOS build from the command line:
+
+```bash
+xcodebuild build \
+    -scheme SwiftSFCGAL \
+    -destination 'generic/platform=iOS Simulator'
+```
+
+If you need to rebuild the XCFrameworks from source (e.g. to target a different SFCGAL version), see [`scripts/create-xcframeworks.sh`](scripts/create-xcframeworks.sh) and the [build-xcframeworks workflow](.github/workflows/build-xcframeworks.yml).
+
 ## Architecture
 
-### Why a C API bridge (not Swift–C++ interop)
+### Why a C API bridge (not Swift-C++ interop)
 
 SFCGAL depends on CGAL, which is one of the most template-heavy C++ libraries in existence. Swift's C++ interoperability (introduced in Swift 5.9) **cannot import uninstantiated C++ templates** — it only supports explicitly pre-instantiated specializations exposed via `typedef` or `using`. CGAL's architecture is built entirely on template metaprogramming: geometric kernels parameterized on number types, traits classes, template template parameters, and deep Boost dependency chains. Additional unsupported features critical to CGAL include rvalue references, C++ exceptions, variadic templates, and `std::function`.
 
-Attempting to pre-instantiate all needed CGAL types is impractical given the sheer volume and interdependency of CGAL's template graph. **Direct Swift–C++ interop with CGAL is a dead end.**
+Attempting to pre-instantiate all needed CGAL types is impractical given the sheer volume and interdependency of CGAL's template graph. **Direct Swift-C++ interop with CGAL is a dead end.**
 
-Instead, this package bridges through **SFCGAL's existing C API** (`sfcgal_c.h`), which uses the opaque pointer pattern — all geometry types are represented as `typedef void sfcgal_geometry_t*` with create/access/delete functions. This C API covers roughly 70–80% of SFCGAL's full functionality and is the same API used by PostGIS, PySFCGAL (Python), and sfcgal-rs (Rust).
+Instead, this package bridges through **SFCGAL's existing C API** (`sfcgal_c.h`), which uses the opaque pointer pattern — all geometry types are represented as `typedef void sfcgal_geometry_t*` with create/access/delete functions. This C API covers roughly 70-80% of SFCGAL's full functionality and is the same API used by PostGIS, PySFCGAL (Python), and sfcgal-rs (Rust).
 
 **Performance impact: zero.** C function calls from Swift have no measurable overhead in release builds. The computational geometry operations themselves (triangulation, Boolean ops, etc.) are orders of magnitude more expensive than the function-call boundary.
 
@@ -78,65 +239,52 @@ The SFCGAL C API (`sfcgal_c.h`) exposes:
 
 ### Package structure
 
-The package uses a **hybrid architecture** with platform-conditional dependencies (SE-0273):
+The package uses a **hybrid architecture** with platform-conditional dependencies ([SE-0273](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0273-swiftpm-conditional-target-dependencies.md)):
 
 ```
 SwiftSFCGAL/
-├── Package.swift                    # Hybrid: systemLibrary (macOS/Linux) + binaryTarget (iOS)
+├── Package.swift                       # Hybrid: systemLibrary + binaryTarget
 ├── Sources/
-│   ├── CSFCGAL_System/              # systemLibrary target (macOS/Linux)
+│   ├── CSFCGAL_System/                 # systemLibrary target (macOS/Linux/Windows)
 │   │   ├── module.modulemap
-│   │   └── sfcgal_shim.h            # Umbrella header
-│   ├── CSFCGAL_Shim/                # Custom C shims (error handling, batch ops)
+│   │   └── sfcgal_shim.h              # Umbrella header (#include <SFCGAL/capi/sfcgal_c.h>)
+│   ├── CSFCGAL_Shim/                   # Cross-platform C shim layer
 │   │   ├── include/
-│   │   │   └── sfcgal_swift_shim.h
-│   │   └── sfcgal_swift_shim.c
-│   └── SwiftSFCGAL/                 # Idiomatic Swift wrapper layer
-│       ├── Geometry.swift            # Base geometry class (RAII via deinit)
-│       ├── Point.swift
-│       ├── Polygon.swift
-│       ├── Operations.swift          # Spatial operations
-│       ├── IO.swift                  # WKT/WKB I/O
-│       └── ...
-├── SFCGAL.xcframework/              # Prebuilt static libraries for iOS
-├── GMP.xcframework/
-├── MPFR.xcframework/
-└── Tests/
-    └── SwiftSFCGALTests/
+│   │   │   └── sfcgal_swift_shim.h    # Public header + SWIFTSFCGAL_REQUIRED_VERSION
+│   │   ├── sfcgal_swift_shim.c        # Empty .c so SPM recognizes the target
+│   │   └── version_check.cc           # Compile-time static_assert on SFCGAL version
+│   └── SwiftSFCGAL/
+│       └── SwiftSFCGAL.swift           # Public Swift API
+├── Tests/
+│   └── SwiftSFCGALTests/
+│       └── SwiftSFCGALTests.swift
+├── scripts/
+│   └── create-xcframeworks.sh          # Builds iOS XCFrameworks from source
+└── .github/workflows/
+    ├── ci.yml                          # CI: macOS, iOS Simulator, Linux, Windows
+    └── build-xcframeworks.yml          # Builds + publishes XCFramework releases
 ```
 
-On **macOS and Linux**, the package links against system-installed SFCGAL via `pkg-config` (e.g., `brew install sfcgal` on macOS, `apt install libsfcgal-dev` on Linux). The `CSFCGAL_System` target contains only a module map and umbrella header — no source code. These tell the Swift compiler how to import the system-installed C API:
+On **macOS, Linux, and Windows**, the package links against a locally installed SFCGAL via `pkg-config` (or, on Windows, via `LIB`/`INCLUDE` env vars). The `CSFCGAL_System` target contains only a module map and umbrella header:
 
-`Sources/CSFCGAL_System/module.modulemap`:
 ```modulemap
 module CSFCGAL_System [system] {
-    umbrella header "sfcgal_shim.h"
+    header "sfcgal_shim.h"
     link "SFCGAL"
     export *
 }
 ```
 
-`Sources/CSFCGAL_System/sfcgal_shim.h`:
-```c
-#include <SFCGAL/capi/sfcgal_c.h>
-```
+On **iOS** (and tvOS, watchOS, visionOS), there is no system library ecosystem. The package uses prebuilt XCFrameworks downloaded from GitHub releases by SPM. These contain static libraries for SFCGAL, GMP, and MPFR cross-compiled for ARM64.
 
-When SFCGAL is installed on the system, it provides a `sfcgal.pc` file (a [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) descriptor). SPM reads this file to automatically resolve the correct `-I` (header) and `-L`/`-l` (linker) flags. No manual path configuration is needed — the system package manager handles the entire dependency tree, and `pkg-config` tells SPM where everything lives.
+### Platform-specific notes
 
-| Platform | pkg-config availability |
-|----------|------------------------|
-| macOS (Homebrew) | `sfcgal.pc` installed automatically by `brew install sfcgal` |
-| Ubuntu / Debian | `sfcgal.pc` installed by `apt install libsfcgal-dev` |
-
-On **iOS** (and visionOS, tvOS, watchOS), there is no system library ecosystem. iOS apps must bundle all non-Apple code inside the `.app` directory. The package therefore includes prebuilt static libraries packaged as XCFrameworks. These are compiled from the same SFCGAL source code but cross-compiled for the iOS ARM64 architecture and platform.
-
-### Why XCFrameworks are required for iOS
-
-SPM's `.systemLibrary` with `pkgConfig` is fundamentally host-platform-only. At package resolution time, SPM's built-in pkg-config parser searches the *build machine's* filesystem for `.pc` files and extracts compiler/linker flags. These flags point to macOS-architecture binaries (e.g., `/opt/homebrew/lib/libSFCGAL.dylib`). When Xcode cross-compiles for `arm64-apple-iphoneos`, the linker rejects these macOS binaries because the `LC_BUILD_VERSION` load command encodes the platform — the linker produces: `ld: building for iOS, but linking in object file built for macOS`.
-
-There is no mechanism in SPM to make `systemLibrary` find iOS-compatible libraries. iOS has no user-installable library ecosystem, no `/usr/lib` for third-party code, and the kernel enforces code-signing at page-fault time (`CS_KILL` flag). All non-Apple code must be embedded in the `.app` bundle.
-
-Vendoring the full source tree (GMP + MPFR + Boost + CGAL + SFCGAL) into SPM is impractical because GMP requires a `./configure` step that generates platform-specific headers, Boost alone is 20,000+ header files, and clean builds would take many minutes.
+| Platform | pkg-config | How paths are resolved |
+|----------|------------|----------------------|
+| macOS (Homebrew) | `sfcgal.pc` installed by `brew install sfcgal` | Automatic via SPM's built-in pkg-config parser |
+| Ubuntu / Debian | `sfcgal.pc` generated by `cmake --install` | Automatic via SPM, with `PKG_CONFIG_PATH` pointing to the install prefix |
+| Windows | SFCGAL's `.pc` file has an empty `prefix=` that SPM cannot parse | Bypassed entirely; paths set through `LIB`/`INCLUDE` env vars and `-Xcc -I` flags |
+| iOS / tvOS / watchOS / visionOS | N/A | XCFrameworks are self-contained; no system paths needed |
 
 ## Dependency chain
 
@@ -154,7 +302,7 @@ SwiftSFCGAL (this package)
 
 ### Cross-compilation notes
 
-- **GMP** is the trickiest dependency for iOS. Its hand-tuned assembly code produces `"unknown AArch64 fixup kind!"` errors when targeting `arm64-apple-iphoneos`. The solution is `./configure --disable-assembly`, which forces generic C fallback code. This incurs a 2–5× slowdown for pure arbitrary-precision arithmetic, but the practical impact on SFCGAL operations is modest because CGAL uses interval filtering (exact arithmetic only triggers on degenerate cases).
+- **GMP** is the trickiest dependency for iOS. Its hand-tuned assembly code produces `"unknown AArch64 fixup kind!"` errors when targeting `arm64-apple-iphoneos`. The solution is `./configure --disable-assembly`, which forces generic C fallback code. This incurs a 2-5x slowdown for pure arbitrary-precision arithmetic, but the practical impact on SFCGAL operations is modest because CGAL uses interval filtering (exact arithmetic only triggers on degenerate cases).
 - **MPFR** is pure C and cross-compiles cleanly once GMP is built — just pass `--with-gmp=<path>`.
 - **CGAL** is header-only since v5.0 — no compilation needed, just include the headers.
 - **Boost** only needs headers for CGAL (no compiled Boost libraries required).
@@ -210,30 +358,18 @@ print("Area: \(area)")  // polygon and triangulated freed automatically when sco
 
 A thin C shim layer sits between the raw SFCGAL C API and Swift to handle:
 - **Error handling:** SFCGAL's default error handler calls `printf`/`abort()`. The shim installs a custom handler that captures errors into a thread-local buffer, which Swift retrieves and throws as proper Swift errors.
-- **Batch operations:** For processing large geometry datasets (e.g., hundreds of CityGML building surfaces), batch shims minimize Swift↔C boundary crossings by processing arrays of geometries in a single C call.
+- **Batch operations:** For processing large geometry datasets (e.g., hundreds of CityGML building surfaces), batch shims minimize Swift-C boundary crossings by processing arrays of geometries in a single C call.
 
-## Development setup
+## CI
 
-### macOS
+The project has automated CI on all supported platforms via GitHub Actions. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for the full workflow. The setup instructions in this README are derived directly from the CI workflow and are verified on every push.
 
-```bash
-brew install sfcgal
-# Then open in Xcode or:
-swift build
-swift test
-```
-
-### Linux (Ubuntu/Debian)
-
-```bash
-sudo apt install libsfcgal-dev
-swift build
-swift test
-```
-
-### iOS
-
-iOS builds require the prebuilt XCFrameworks to be present in the package root. See the [XCFramework build instructions](docs/xcframework-build.md) for details on cross-compiling the dependency chain.
+| Job | Runner | Swift setup |
+|-----|--------|-------------|
+| macOS | `macos-latest` | Xcode-bundled Swift |
+| iOS Simulator | `macos-latest` | Xcode-bundled Swift + `xcodebuild` |
+| Linux | `ubuntu-latest` | [swift-actions/setup-swift](https://github.com/swift-actions/setup-swift) |
+| Windows | `windows-latest` | [compnerd/gha-setup-swift](https://github.com/compnerd/gha-setup-swift) |
 
 ## Status
 

--- a/Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
+++ b/Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
@@ -3,4 +3,9 @@
 
 #include <SFCGAL/capi/sfcgal_c.h>
 
+// Single source of truth for the required SFCGAL version.
+// The compile-time check in version_check.cc enforces this at build time.
+// Also visible to Swift via the CSFCGAL_Shim module.
+#define SWIFTSFCGAL_REQUIRED_VERSION "2.2.0"
+
 #endif /* SFCGAL_SWIFT_SHIM_H */

--- a/Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
+++ b/Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
@@ -1,0 +1,6 @@
+#ifndef SFCGAL_SWIFT_SHIM_H
+#define SFCGAL_SWIFT_SHIM_H
+
+#include <SFCGAL/capi/sfcgal_c.h>
+
+#endif /* SFCGAL_SWIFT_SHIM_H */

--- a/Sources/CSFCGAL_Shim/sfcgal_swift_shim.c
+++ b/Sources/CSFCGAL_Shim/sfcgal_swift_shim.c
@@ -1,0 +1,3 @@
+// Empty — this file exists so SPM recognizes this as a C target.
+// The shim's value is its public umbrella header, which re-exports
+// the SFCGAL C API from whichever platform-specific module is linked.

--- a/Sources/CSFCGAL_Shim/sfcgal_swift_shim.c
+++ b/Sources/CSFCGAL_Shim/sfcgal_swift_shim.c
@@ -1,3 +1,3 @@
-// Empty — this file exists so SPM recognizes this as a C target.
+// This file exists so SPM recognizes this as a C target.
 // The shim's value is its public umbrella header, which re-exports
 // the SFCGAL C API from whichever platform-specific module is linked.

--- a/Sources/CSFCGAL_Shim/version_check.cc
+++ b/Sources/CSFCGAL_Shim/version_check.cc
@@ -1,0 +1,11 @@
+// Compile-time check that the system SFCGAL version matches SwiftSFCGAL.
+// This file is C++ because SFCGAL/version.h contains C++ code (namespace).
+
+#include <SFCGAL/version.h>
+#include "include/sfcgal_swift_shim.h"
+
+static_assert(
+    __builtin_strcmp(SFCGAL_VERSION, SWIFTSFCGAL_REQUIRED_VERSION) == 0,
+    "SFCGAL version mismatch: SwiftSFCGAL requires exactly SFCGAL " SWIFTSFCGAL_REQUIRED_VERSION
+    ", but found " SFCGAL_VERSION " installed on this system"
+);

--- a/Sources/CSFCGAL_System/module.modulemap
+++ b/Sources/CSFCGAL_System/module.modulemap
@@ -1,0 +1,5 @@
+module CSFCGAL_System [system] {
+    header "sfcgal_shim.h"
+    link "SFCGAL"
+    export *
+}

--- a/Sources/CSFCGAL_System/sfcgal_shim.h
+++ b/Sources/CSFCGAL_System/sfcgal_shim.h
@@ -1,0 +1,6 @@
+#ifndef CSFCGAL_SYSTEM_SHIM_H
+#define CSFCGAL_SYSTEM_SHIM_H
+
+#include <SFCGAL/capi/sfcgal_c.h>
+
+#endif /* CSFCGAL_SYSTEM_SHIM_H */

--- a/Sources/SFCGAL_SPM/SFCGAL.swift
+++ b/Sources/SFCGAL_SPM/SFCGAL.swift
@@ -1,8 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
-
-public func helloWorld() -> String {
-    let message = "Hello, World from SFCGAL!"
-    print(message)
-    return message
-}

--- a/Sources/SwiftSFCGAL/SwiftSFCGAL.swift
+++ b/Sources/SwiftSFCGAL/SwiftSFCGAL.swift
@@ -6,6 +6,20 @@ import CSFCGAL_Binary
 
 import CSFCGAL_Shim
 
+/// The exact SFCGAL version this package is built against.
+/// Must match the version used to build the iOS xcframeworks.
+public let expectedSFCGALVersion = "2.2.0"
+
 public func sfcgalVersion() -> String {
     return String(cString: sfcgal_version())
+}
+
+/// Verifies the linked SFCGAL library matches the expected version.
+/// Call this at app startup to catch version mismatches early.
+public func validateSFCGALVersion() {
+    let actual = sfcgalVersion()
+    precondition(
+        actual == expectedSFCGALVersion,
+        "SFCGAL version mismatch: found \(actual) but this package requires exactly \(expectedSFCGALVersion)"
+    )
 }

--- a/Sources/SwiftSFCGAL/SwiftSFCGAL.swift
+++ b/Sources/SwiftSFCGAL/SwiftSFCGAL.swift
@@ -7,8 +7,8 @@ import CSFCGAL_Binary
 import CSFCGAL_Shim
 
 /// The exact SFCGAL version this package is built against.
-/// Must match the version used to build the iOS xcframeworks.
-public let expectedSFCGALVersion = "2.2.0"
+/// Sourced from CSFCGAL_Shim — single source of truth shared with the compile-time check.
+public let expectedSFCGALVersion: String = SWIFTSFCGAL_REQUIRED_VERSION
 
 public func sfcgalVersion() -> String {
     return String(cString: sfcgal_version())
@@ -20,6 +20,6 @@ public func validateSFCGALVersion() {
     let actual = sfcgalVersion()
     precondition(
         actual == expectedSFCGALVersion,
-        "SFCGAL version mismatch: found \(actual) but this package requires exactly \(expectedSFCGALVersion)"
+        "SFCGAL version mismatch: SwiftSFCGAL requires exactly SFCGAL \(expectedSFCGALVersion), but found \(actual) installed on this system"
     )
 }

--- a/Sources/SwiftSFCGAL/SwiftSFCGAL.swift
+++ b/Sources/SwiftSFCGAL/SwiftSFCGAL.swift
@@ -1,0 +1,11 @@
+#if canImport(CSFCGAL_System)
+import CSFCGAL_System
+#elseif canImport(CSFCGAL_Binary)
+import CSFCGAL_Binary
+#endif
+
+import CSFCGAL_Shim
+
+public func sfcgalVersion() -> String {
+    return String(cString: sfcgal_version())
+}

--- a/Tests/SFCGAL_SPMTests/SFCGAL_Tests.swift
+++ b/Tests/SFCGAL_SPMTests/SFCGAL_Tests.swift
@@ -1,7 +1,0 @@
-import Testing
-@testable import SFCGAL
-
-@Test func helloWorldTest() {
-    let result = helloWorld()
-    #expect(result == "Hello, World from SFCGAL!")
-}

--- a/Tests/SwiftSFCGALTests/SwiftSFCGALTests.swift
+++ b/Tests/SwiftSFCGALTests/SwiftSFCGALTests.swift
@@ -1,0 +1,7 @@
+import Testing
+@testable import SwiftSFCGAL
+
+@Test func testSfcgalVersion() {
+    let version = sfcgalVersion()
+    #expect(!version.isEmpty, "SFCGAL version string should not be empty")
+}

--- a/Tests/SwiftSFCGALTests/SwiftSFCGALTests.swift
+++ b/Tests/SwiftSFCGALTests/SwiftSFCGALTests.swift
@@ -3,5 +3,6 @@ import Testing
 
 @Test func testSfcgalVersion() {
     let version = sfcgalVersion()
-    #expect(!version.isEmpty, "SFCGAL version string should not be empty")
+    #expect(version == expectedSFCGALVersion,
+        "SFCGAL version mismatch: got \(version), expected \(expectedSFCGALVersion)")
 }

--- a/scripts/build-gmp-ios.sh
+++ b/scripts/build-gmp-ios.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# build-gmp-ios.sh — Cross-compile GMP 6.3.0 for iOS device and simulator
+#
+# Produces:
+#   $OUTPUT_DIR/ios-arm64/          — device (arm64, platform IOS)
+#   $OUTPUT_DIR/simulator-arm64/    — simulator Apple Silicon (arm64, platform IOS_SIMULATOR)
+#   $OUTPUT_DIR/simulator-x86_64/   — simulator Intel (x86_64, platform IOS_SIMULATOR)
+#   $OUTPUT_DIR/simulator-fat/      — merged simulator (arm64 + x86_64)
+#
+# Usage:
+#   ./scripts/build-gmp-ios.sh [output_dir]
+#
+# Requirements:
+#   - Xcode (not just Command Line Tools) for iOS SDKs
+#   - curl, tar, lipo, otool
+
+set -euo pipefail
+
+GMP_VERSION="6.3.0"
+GMP_URL="https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz"
+IOS_MIN_VERSION="15.0"
+
+OUTPUT_DIR="${1:-$(pwd)/gmp-ios-build}"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+NCPU=$(sysctl -n hw.ncpu)
+
+echo "=== Downloading GMP ${GMP_VERSION} ==="
+curl -sL "$GMP_URL" -o "$WORK_DIR/gmp.tar.xz"
+tar xf "$WORK_DIR/gmp.tar.xz" -C "$WORK_DIR"
+GMP_SRC="$WORK_DIR/gmp-${GMP_VERSION}"
+
+# Build GMP for a single target
+# Arguments: $1=sdk_name $2=arch $3=target_triple $4=host_triplet $5=install_prefix
+build_gmp() {
+    local sdk_name="$1"
+    local arch="$2"
+    local target_triple="$3"
+    local host_triplet="$4"
+    local prefix="$5"
+
+    local sdk_path
+    sdk_path=$(xcrun --sdk "$sdk_name" --show-sdk-path)
+    local cc
+    cc=$(xcrun --sdk "$sdk_name" --find clang)
+    local cxx
+    cxx=$(xcrun --sdk "$sdk_name" --find clang++)
+
+    local cflags="-arch ${arch} -isysroot ${sdk_path} -target ${target_triple} -O2"
+    local ldflags="-arch ${arch} -isysroot ${sdk_path} -target ${target_triple}"
+
+    local build_dir="$WORK_DIR/build-${sdk_name}-${arch}"
+    mkdir -p "$build_dir"
+
+    echo "=== Configuring GMP for ${sdk_name} ${arch} ==="
+    (
+        cd "$build_dir"
+        "$GMP_SRC/configure" \
+            --host="$host_triplet" \
+            --disable-assembly \
+            --enable-static \
+            --disable-shared \
+            --prefix="$prefix" \
+            CC="$cc" \
+            CXX="$cxx" \
+            CFLAGS="$cflags" \
+            CXXFLAGS="$cflags" \
+            LDFLAGS="$ldflags" \
+            > /dev/null 2>&1
+    )
+
+    echo "=== Building GMP for ${sdk_name} ${arch} ==="
+    make -C "$build_dir" -j"$NCPU" > /dev/null 2>&1
+
+    echo "=== Installing GMP for ${sdk_name} ${arch} ==="
+    make -C "$build_dir" install > /dev/null 2>&1
+}
+
+mkdir -p "$OUTPUT_DIR"
+
+# 1. iOS device (arm64)
+build_gmp \
+    iphoneos \
+    arm64 \
+    "arm64-apple-ios${IOS_MIN_VERSION}" \
+    aarch64-apple-darwin \
+    "$OUTPUT_DIR/ios-arm64"
+
+# 2. iOS Simulator (arm64, Apple Silicon)
+build_gmp \
+    iphonesimulator \
+    arm64 \
+    "arm64-apple-ios${IOS_MIN_VERSION}-simulator" \
+    aarch64-apple-darwin \
+    "$OUTPUT_DIR/simulator-arm64"
+
+# 3. iOS Simulator (x86_64, Intel)
+build_gmp \
+    iphonesimulator \
+    x86_64 \
+    "x86_64-apple-ios${IOS_MIN_VERSION}-simulator" \
+    x86_64-apple-darwin \
+    "$OUTPUT_DIR/simulator-x86_64"
+
+# 4. Create fat simulator library
+echo "=== Creating fat simulator library ==="
+mkdir -p "$OUTPUT_DIR/simulator-fat/lib"
+cp -R "$OUTPUT_DIR/simulator-arm64/include" "$OUTPUT_DIR/simulator-fat/include"
+lipo -create \
+    "$OUTPUT_DIR/simulator-arm64/lib/libgmp.a" \
+    "$OUTPUT_DIR/simulator-x86_64/lib/libgmp.a" \
+    -output "$OUTPUT_DIR/simulator-fat/lib/libgmp.a"
+
+# 5. Verify all outputs
+echo ""
+echo "=== Verification ==="
+verify_lib() {
+    local lib="$1"
+    local expected_platform="$2"
+    local label="$3"
+
+    local arch
+    arch=$(lipo -info "$lib" 2>&1)
+    local platform
+    platform=$(otool -l "$lib" 2>&1 | grep -A2 LC_BUILD_VERSION | grep platform | head -1 | awk '{print $2}')
+
+    local status="OK"
+    if [ "$platform" != "$expected_platform" ]; then
+        status="FAIL (expected platform $expected_platform, got $platform)"
+    fi
+
+    echo "  ${label}: ${arch} | platform=${platform} | ${status}"
+}
+
+# platform 2 = IOS, platform 7 = IOS_SIMULATOR
+verify_lib "$OUTPUT_DIR/ios-arm64/lib/libgmp.a" "2" "iOS device arm64"
+verify_lib "$OUTPUT_DIR/simulator-arm64/lib/libgmp.a" "7" "Simulator arm64"
+verify_lib "$OUTPUT_DIR/simulator-x86_64/lib/libgmp.a" "7" "Simulator x86_64"
+
+echo "  Simulator fat: $(lipo -info "$OUTPUT_DIR/simulator-fat/lib/libgmp.a")"
+
+echo ""
+echo "=== Build complete ==="
+echo "Output: $OUTPUT_DIR"
+echo ""
+echo "Directory structure:"
+find "$OUTPUT_DIR" -name "*.a" -o -name "*.h" | sort | head -20

--- a/scripts/build-gmp-ios.sh
+++ b/scripts/build-gmp-ios.sh
@@ -21,7 +21,7 @@ GMP_VERSION="6.3.0"
 GMP_URL="https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz"
 IOS_MIN_VERSION="15.0"
 
-OUTPUT_DIR="${1:-$(pwd)/gmp-ios-build}"
+OUTPUT_DIR="$(cd "$(dirname "${1:-$(pwd)/gmp-ios-build}")" && pwd)/$(basename "${1:-$(pwd)/gmp-ios-build}")"
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
 

--- a/scripts/build-gmp-ios.sh
+++ b/scripts/build-gmp-ios.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-GMP_VERSION="6.3.0"
+GMP_VERSION="${GMP_VERSION_OVERRIDE:-6.3.0}"
 GMP_URL="https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz"
 IOS_MIN_VERSION="15.0"
 

--- a/scripts/build-gmp-ios.sh
+++ b/scripts/build-gmp-ios.sh
@@ -18,7 +18,10 @@
 set -euo pipefail
 
 GMP_VERSION="${GMP_VERSION_OVERRIDE:-6.3.0}"
-GMP_URL="https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz"
+GMP_URLS=(
+    "https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz"
+    "https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.xz"
+)
 IOS_MIN_VERSION="15.0"
 
 OUTPUT_DIR="$(cd "$(dirname "${1:-$(pwd)/gmp-ios-build}")" && pwd)/$(basename "${1:-$(pwd)/gmp-ios-build}")"
@@ -27,8 +30,25 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 NCPU=$(sysctl -n hw.ncpu)
 
+# Download with retry and fallback mirrors
+download_with_retry() {
+    local output="$1"
+    shift
+    local urls=("$@")
+    for url in "${urls[@]}"; do
+        echo "  Trying: $url"
+        if curl -fSL --retry 3 --retry-delay 5 --connect-timeout 30 "$url" -o "$output"; then
+            echo "  Downloaded from: $url"
+            return 0
+        fi
+        echo "  Failed, trying next mirror..."
+    done
+    echo "ERROR: All download mirrors failed."
+    exit 1
+}
+
 echo "=== Downloading GMP ${GMP_VERSION} ==="
-curl -sL "$GMP_URL" -o "$WORK_DIR/gmp.tar.xz"
+download_with_retry "$WORK_DIR/gmp.tar.xz" "${GMP_URLS[@]}"
 tar xf "$WORK_DIR/gmp.tar.xz" -C "$WORK_DIR"
 GMP_SRC="$WORK_DIR/gmp-${GMP_VERSION}"
 

--- a/scripts/build-mpfr-ios.sh
+++ b/scripts/build-mpfr-ios.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# build-mpfr-ios.sh — Cross-compile MPFR 4.2.1 for iOS device and simulator
+#
+# Produces:
+#   $OUTPUT_DIR/ios-arm64/          — device (arm64, platform IOS)
+#   $OUTPUT_DIR/simulator-arm64/    — simulator Apple Silicon (arm64, platform IOS_SIMULATOR)
+#   $OUTPUT_DIR/simulator-x86_64/   — simulator Intel (x86_64, platform IOS_SIMULATOR)
+#   $OUTPUT_DIR/simulator-fat/      — merged simulator (arm64 + x86_64)
+#
+# Usage:
+#   ./scripts/build-mpfr-ios.sh <gmp_dir> [output_dir]
+#
+#   gmp_dir:    path to GMP cross-compiled output (from build-gmp-ios.sh)
+#   output_dir: where to place MPFR builds (default: ./mpfr-ios-build)
+#
+# Requirements:
+#   - Xcode (not just Command Line Tools) for iOS SDKs
+#   - Cross-compiled GMP (run build-gmp-ios.sh first)
+#   - curl, tar, lipo, otool
+
+set -euo pipefail
+
+MPFR_VERSION="4.2.1"
+MPFR_URL="https://www.mpfr.org/mpfr-${MPFR_VERSION}/mpfr-${MPFR_VERSION}.tar.xz"
+IOS_MIN_VERSION="15.0"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <gmp_dir> [output_dir]"
+    echo "  gmp_dir:    path to GMP cross-compiled output (from build-gmp-ios.sh)"
+    echo "  output_dir: where to place MPFR builds (default: ./mpfr-ios-build)"
+    exit 1
+fi
+
+GMP_DIR="$(cd "$1" && pwd)"
+OUTPUT_DIR="$(mkdir -p "${2:-$(pwd)/mpfr-ios-build}" && cd "${2:-$(pwd)/mpfr-ios-build}" && pwd)"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+NCPU=$(sysctl -n hw.ncpu)
+
+# Validate GMP builds exist
+for variant in ios-arm64 simulator-arm64 simulator-x86_64; do
+    if [ ! -f "$GMP_DIR/$variant/lib/libgmp.a" ]; then
+        echo "ERROR: Missing GMP build at $GMP_DIR/$variant/lib/libgmp.a"
+        echo "Run build-gmp-ios.sh first."
+        exit 1
+    fi
+done
+
+echo "=== Downloading MPFR ${MPFR_VERSION} ==="
+curl -sL "$MPFR_URL" -o "$WORK_DIR/mpfr.tar.xz"
+tar xf "$WORK_DIR/mpfr.tar.xz" -C "$WORK_DIR"
+MPFR_SRC="$WORK_DIR/mpfr-${MPFR_VERSION}"
+
+# Build MPFR for a single target
+# Arguments: $1=sdk_name $2=arch $3=target_triple $4=host_triplet $5=install_prefix $6=gmp_prefix
+build_mpfr() {
+    local sdk_name="$1"
+    local arch="$2"
+    local target_triple="$3"
+    local host_triplet="$4"
+    local prefix="$5"
+    local gmp_prefix="$6"
+
+    local sdk_path
+    sdk_path=$(xcrun --sdk "$sdk_name" --show-sdk-path)
+    local cc
+    cc=$(xcrun --sdk "$sdk_name" --find clang)
+
+    local cflags="-arch ${arch} -isysroot ${sdk_path} -target ${target_triple} -O2"
+    local ldflags="-arch ${arch} -isysroot ${sdk_path} -target ${target_triple}"
+
+    local build_dir="$WORK_DIR/build-${sdk_name}-${arch}"
+    mkdir -p "$build_dir"
+
+    echo "=== Configuring MPFR for ${sdk_name} ${arch} ==="
+    (
+        cd "$build_dir"
+        "$MPFR_SRC/configure" \
+            --host="$host_triplet" \
+            --enable-static \
+            --disable-shared \
+            --with-gmp="$gmp_prefix" \
+            --prefix="$prefix" \
+            CC="$cc" \
+            CFLAGS="$cflags" \
+            LDFLAGS="$ldflags" \
+            > /dev/null 2>&1
+    )
+
+    echo "=== Building MPFR for ${sdk_name} ${arch} ==="
+    make -C "$build_dir" -j"$NCPU" > /dev/null 2>&1
+
+    echo "=== Installing MPFR for ${sdk_name} ${arch} ==="
+    make -C "$build_dir" install > /dev/null 2>&1
+}
+
+mkdir -p "$OUTPUT_DIR"
+
+# 1. iOS device (arm64)
+build_mpfr \
+    iphoneos \
+    arm64 \
+    "arm64-apple-ios${IOS_MIN_VERSION}" \
+    aarch64-apple-darwin \
+    "$OUTPUT_DIR/ios-arm64" \
+    "$GMP_DIR/ios-arm64"
+
+# 2. iOS Simulator (arm64, Apple Silicon)
+build_mpfr \
+    iphonesimulator \
+    arm64 \
+    "arm64-apple-ios${IOS_MIN_VERSION}-simulator" \
+    aarch64-apple-darwin \
+    "$OUTPUT_DIR/simulator-arm64" \
+    "$GMP_DIR/simulator-arm64"
+
+# 3. iOS Simulator (x86_64, Intel)
+build_mpfr \
+    iphonesimulator \
+    x86_64 \
+    "x86_64-apple-ios${IOS_MIN_VERSION}-simulator" \
+    x86_64-apple-darwin \
+    "$OUTPUT_DIR/simulator-x86_64" \
+    "$GMP_DIR/simulator-x86_64"
+
+# 4. Create fat simulator library
+echo "=== Creating fat simulator library ==="
+mkdir -p "$OUTPUT_DIR/simulator-fat/lib"
+cp -R "$OUTPUT_DIR/simulator-arm64/include" "$OUTPUT_DIR/simulator-fat/include"
+lipo -create \
+    "$OUTPUT_DIR/simulator-arm64/lib/libmpfr.a" \
+    "$OUTPUT_DIR/simulator-x86_64/lib/libmpfr.a" \
+    -output "$OUTPUT_DIR/simulator-fat/lib/libmpfr.a"
+
+# 5. Verify all outputs
+echo ""
+echo "=== Verification ==="
+verify_lib() {
+    local lib="$1"
+    local expected_platform="$2"
+    local label="$3"
+
+    local arch
+    arch=$(lipo -info "$lib" 2>&1)
+    local platform
+    platform=$(otool -l "$lib" 2>&1 | grep -A2 LC_BUILD_VERSION | grep platform | head -1 | awk '{print $2}')
+
+    local status="OK"
+    if [ "$platform" != "$expected_platform" ]; then
+        status="FAIL (expected platform $expected_platform, got $platform)"
+    fi
+
+    echo "  ${label}: ${arch} | platform=${platform} | ${status}"
+}
+
+# platform 2 = IOS, platform 7 = IOS_SIMULATOR
+verify_lib "$OUTPUT_DIR/ios-arm64/lib/libmpfr.a" "2" "iOS device arm64"
+verify_lib "$OUTPUT_DIR/simulator-arm64/lib/libmpfr.a" "7" "Simulator arm64"
+verify_lib "$OUTPUT_DIR/simulator-x86_64/lib/libmpfr.a" "7" "Simulator x86_64"
+
+echo "  Simulator fat: $(lipo -info "$OUTPUT_DIR/simulator-fat/lib/libmpfr.a")"
+
+# 6. Test linking with a minimal program
+echo ""
+echo "=== Link test ==="
+TEST_DIR="$WORK_DIR/link-test"
+mkdir -p "$TEST_DIR"
+
+cat > "$TEST_DIR/test_mpfr.c" << 'CEOF'
+#include <mpfr.h>
+#include <stdio.h>
+
+int main(void) {
+    mpfr_t x;
+    mpfr_init2(x, 256);
+    mpfr_set_d(x, 3.14159, MPFR_RNDN);
+    mpfr_clear(x);
+    printf("MPFR %s linked OK\n", mpfr_get_version());
+    return 0;
+}
+CEOF
+
+IOS_SDK=$(xcrun --sdk iphoneos --show-sdk-path)
+IOS_CC=$(xcrun --sdk iphoneos --find clang)
+
+"$IOS_CC" \
+    -arch arm64 \
+    -isysroot "$IOS_SDK" \
+    -target "arm64-apple-ios${IOS_MIN_VERSION}" \
+    -I"$OUTPUT_DIR/ios-arm64/include" \
+    -I"$GMP_DIR/ios-arm64/include" \
+    -L"$OUTPUT_DIR/ios-arm64/lib" \
+    -L"$GMP_DIR/ios-arm64/lib" \
+    -lmpfr -lgmp \
+    -o "$TEST_DIR/test_mpfr" \
+    "$TEST_DIR/test_mpfr.c" \
+    2>&1
+
+if [ $? -eq 0 ]; then
+    echo "  Link test: OK"
+    file "$TEST_DIR/test_mpfr"
+else
+    echo "  Link test: FAIL"
+    exit 1
+fi
+
+echo ""
+echo "=== Build complete ==="
+echo "Output: $OUTPUT_DIR"
+echo ""
+echo "Directory structure:"
+find "$OUTPUT_DIR" -name "*.a" -o -name "*.h" | sort | head -20

--- a/scripts/build-mpfr-ios.sh
+++ b/scripts/build-mpfr-ios.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-MPFR_VERSION="4.2.1"
+MPFR_VERSION="${MPFR_VERSION_OVERRIDE:-4.2.1}"
 MPFR_URL="https://www.mpfr.org/mpfr-${MPFR_VERSION}/mpfr-${MPFR_VERSION}.tar.xz"
 IOS_MIN_VERSION="15.0"
 

--- a/scripts/build-mpfr-ios.sh
+++ b/scripts/build-mpfr-ios.sh
@@ -22,7 +22,10 @@
 set -euo pipefail
 
 MPFR_VERSION="${MPFR_VERSION_OVERRIDE:-4.2.1}"
-MPFR_URL="https://www.mpfr.org/mpfr-${MPFR_VERSION}/mpfr-${MPFR_VERSION}.tar.xz"
+MPFR_URLS=(
+    "https://www.mpfr.org/mpfr-${MPFR_VERSION}/mpfr-${MPFR_VERSION}.tar.xz"
+    "https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
+)
 IOS_MIN_VERSION="15.0"
 
 if [ $# -lt 1 ]; then
@@ -39,6 +42,23 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 NCPU=$(sysctl -n hw.ncpu)
 
+# Download with retry and fallback mirrors
+download_with_retry() {
+    local output="$1"
+    shift
+    local urls=("$@")
+    for url in "${urls[@]}"; do
+        echo "  Trying: $url"
+        if curl -fSL --retry 3 --retry-delay 5 --connect-timeout 30 "$url" -o "$output"; then
+            echo "  Downloaded from: $url"
+            return 0
+        fi
+        echo "  Failed, trying next mirror..."
+    done
+    echo "ERROR: All download mirrors failed."
+    exit 1
+}
+
 # Validate GMP builds exist
 for variant in ios-arm64 simulator-arm64 simulator-x86_64; do
     if [ ! -f "$GMP_DIR/$variant/lib/libgmp.a" ]; then
@@ -49,7 +69,7 @@ for variant in ios-arm64 simulator-arm64 simulator-x86_64; do
 done
 
 echo "=== Downloading MPFR ${MPFR_VERSION} ==="
-curl -sL "$MPFR_URL" -o "$WORK_DIR/mpfr.tar.xz"
+download_with_retry "$WORK_DIR/mpfr.tar.xz" "${MPFR_URLS[@]}"
 tar xf "$WORK_DIR/mpfr.tar.xz" -C "$WORK_DIR"
 MPFR_SRC="$WORK_DIR/mpfr-${MPFR_VERSION}"
 

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -308,7 +308,7 @@ with open('$build_dir/compile_commands.json') as f:
 " 2>/dev/null || echo "  (could not parse compile_commands.json)"
     fi
 
-    # Quick nm check on first arch only
+    # Check for Sphere/Cylinder constructor symbols specifically
     if [ "$arch" = "arm64" ] && [ "$sdk_name" = "iphoneos" ]; then
         local lib_a
         lib_a=$(find "$build_dir" -name "libSFCGAL.a" | head -1)
@@ -316,15 +316,29 @@ with open('$build_dir/compile_commands.json') as f:
             local extract_dir="$build_dir/nm-check"
             mkdir -p "$extract_dir"
             (cd "$extract_dir" && ar x "$lib_a" Sphere.cpp.o 2>/dev/null) || true
-            if [ -f "$extract_dir/Sphere.cpp.o" ]; then
-                echo "=== SFCGAL:: symbols in Sphere.cpp.o ==="
-                nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "6SFCGAL" | head -15 || echo "  NONE"
-            fi
+            (cd "$extract_dir" && ar x "$lib_a" Cylinder.cpp.o 2>/dev/null) || true
+
+            echo "=== All SFCGAL::Sphere symbols (no limit) ==="
+            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "6SFCGAL6Sphere" || echo "  NONE"
+
+            echo "=== All SFCGAL::Cylinder symbols (no limit) ==="
+            nm "$extract_dir/Cylinder.cpp.o" 2>/dev/null | grep "6SFCGAL8Cylinder" || echo "  NONE"
+
+            echo "=== Specifically looking for constructors (C1/C2) ==="
+            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "6SphereC" || echo "  No Sphere constructor"
+            nm "$extract_dir/Cylinder.cpp.o" 2>/dev/null | grep "8CylinderC" || echo "  No Cylinder constructor"
+
         fi
     fi
 
     echo "=== Installing SFCGAL for ${sdk_name} ${arch} ==="
     cmake --install "$build_dir" > /dev/null 2>&1
+
+    # Verify installed library has the constructors
+    if [ "$arch" = "arm64" ] && [ "$sdk_name" = "iphoneos" ]; then
+        echo "=== Constructors in INSTALLED library ==="
+        nm "$prefix/lib/libSFCGAL.a" 2>/dev/null | grep -E "6SphereC|8CylinderC" | head -5 || echo "  MISSING in installed lib"
+    fi
 }
 
 mkdir -p "$OUTPUT_DIR"

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -30,7 +30,7 @@
 
 set -euo pipefail
 
-SFCGAL_VERSION="2.0.0"
+SFCGAL_VERSION="${SFCGAL_VERSION_OVERRIDE:-2.0.0}"
 SFCGAL_URL="https://gitlab.com/sfcgal/SFCGAL/-/archive/v${SFCGAL_VERSION}/SFCGAL-v${SFCGAL_VERSION}.tar.gz"
 CGAL_VERSION="6.0.1"
 CGAL_URL="https://github.com/CGAL/cgal/releases/download/v${CGAL_VERSION}/CGAL-${CGAL_VERSION}.tar.xz"

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -36,7 +36,10 @@ CGAL_VERSION="6.0.1"
 CGAL_URL="https://github.com/CGAL/cgal/releases/download/v${CGAL_VERSION}/CGAL-${CGAL_VERSION}.tar.xz"
 BOOST_VERSION="1.87.0"
 BOOST_VERSION_UNDERSCORE="1_87_0"
-BOOST_URL="https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
+BOOST_URLS=(
+    "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
+    "https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz/download"
+)
 IOS_MIN_VERSION="15.0"
 
 if [ $# -lt 2 ]; then
@@ -54,6 +57,23 @@ WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 NCPU=$(sysctl -n hw.ncpu)
+
+# Download with retry and fallback mirrors
+download_with_retry() {
+    local output="$1"
+    shift
+    local urls=("$@")
+    for url in "${urls[@]}"; do
+        echo "  Trying: $url"
+        if curl -fSL --retry 3 --retry-delay 5 --connect-timeout 30 "$url" -o "$output"; then
+            echo "  Downloaded from: $url"
+            return 0
+        fi
+        echo "  Failed, trying next mirror..."
+    done
+    echo "ERROR: All download mirrors failed."
+    exit 1
+}
 
 # Validate GMP and MPFR builds exist
 for variant in ios-arm64 simulator-arm64 simulator-x86_64; do
@@ -79,17 +99,17 @@ fi
 # =============================================================================
 
 echo "=== Downloading SFCGAL ${SFCGAL_VERSION} ==="
-curl -sL "$SFCGAL_URL" -o "$WORK_DIR/sfcgal.tar.gz"
+download_with_retry "$WORK_DIR/sfcgal.tar.gz" "$SFCGAL_URL"
 tar xf "$WORK_DIR/sfcgal.tar.gz" -C "$WORK_DIR"
 SFCGAL_SRC="$WORK_DIR/SFCGAL-v${SFCGAL_VERSION}"
 
 echo "=== Downloading CGAL ${CGAL_VERSION} (headers only) ==="
-curl -sL "$CGAL_URL" -o "$WORK_DIR/cgal.tar.xz"
+download_with_retry "$WORK_DIR/cgal.tar.xz" "$CGAL_URL"
 tar xf "$WORK_DIR/cgal.tar.xz" -C "$WORK_DIR"
 CGAL_DIR="$WORK_DIR/CGAL-${CGAL_VERSION}"
 
 echo "=== Downloading Boost ${BOOST_VERSION} ==="
-curl -sL "$BOOST_URL" -o "$WORK_DIR/boost.tar.gz"
+download_with_retry "$WORK_DIR/boost.tar.gz" "${BOOST_URLS[@]}"
 tar xf "$WORK_DIR/boost.tar.gz" -C "$WORK_DIR"
 BOOST_ROOT="$WORK_DIR/boost_${BOOST_VERSION_UNDERSCORE}"
 

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -27,6 +27,8 @@
 # Patches applied to SFCGAL source:
 #   - Removes hard-coded set(Boost_USE_STATIC_LIBS OFF) so the cache variable
 #     from our -DBoost_USE_STATIC_LIBS=ON takes effect.
+#   - Disables inlining for src/primitive3d/*.cpp (Sphere, Cylinder) to force
+#     Apple Clang to emit out-of-line constructor symbols at -O2.
 
 set -euo pipefail
 
@@ -123,17 +125,23 @@ BOOST_ROOT="$WORK_DIR/boost_${BOOST_VERSION_UNDERSCORE}"
 sed -i.bak 's/^set(Boost_USE_STATIC_LIBS OFF)/#set(Boost_USE_STATIC_LIBS OFF)  # patched for iOS static build/' \
     "$SFCGAL_SRC/CMakeLists.txt"
 
-# Debug: inject a diagnostic message into src/CMakeLists.txt so we can see
-# exactly which sources GLOB_RECURSE picks up during cross-compilation.
-sed -i.bak2 '/^file( GLOB_RECURSE SFCGAL_SOURCES/a\
-message(STATUS "SFCGAL_SOURCES (glob result): ${SFCGAL_SOURCES}")
-' "$SFCGAL_SRC/src/CMakeLists.txt"
+# Apple Clang at -O2 inlines the Sphere/Cylinder constructors (which have
+# empty bodies with only member-initializer lists) and never emits an
+# out-of-line symbol. buffer3D.cpp references them as external symbols,
+# causing an undefined-symbol link error. Fix: disable inlining for the
+# primitive3d source files so the constructors are always emitted.
+if [ -d "$SFCGAL_SRC/src/primitive3d" ]; then
+    echo "=== Patching src/CMakeLists.txt: disable inlining for primitive3d ==="
+    cat >> "$SFCGAL_SRC/src/CMakeLists.txt" << 'PATCH'
 
-# Debug: check how SFCGAL_API is defined (visibility issue?)
-echo "=== Checking SFCGAL_API / export macro ==="
-grep -n "SFCGAL_API\|visibility\|SFCGAL_BUILD_SHARED\|SFCGAL_USE_STATIC" "$SFCGAL_SRC/src/export.h" || echo "  export.h not found at expected path"
-echo "=== Checking if Sphere.h uses SFCGAL_API ==="
-head -30 "$SFCGAL_SRC/src/primitive3d/Sphere.h" 2>/dev/null || echo "  Sphere.h not found"
+# Patched for iOS cross-compilation: Apple Clang at -O2 inlines Sphere/Cylinder
+# constructors and never emits out-of-line symbols, breaking the link.
+file( GLOB _PRIMITIVE3D_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/primitive3d/*.cpp" )
+if(_PRIMITIVE3D_SOURCES)
+    set_source_files_properties(${_PRIMITIVE3D_SOURCES} PROPERTIES COMPILE_OPTIONS "-fno-inline-functions")
+endif()
+PATCH
+fi
 
 # =============================================================================
 # Build required Boost libraries for iOS
@@ -280,53 +288,10 @@ build_sfcgal() {
         -DMPFR_LIBRARIES="$mpfr_prefix/lib/libmpfr.a" \
         -DCMAKE_CXX_STANDARD=17 \
         -Wno-dev \
-        2>&1 | grep -E "(SFCGAL_SOURCES|primitive3d|Sphere|Cylinder|STATUS)" || true
+        > /dev/null 2>&1
 
     echo "=== Building SFCGAL for ${sdk_name} ${arch} ==="
     cmake --build "$build_dir" --config Release -j"$NCPU" 2>&1 | tail -5
-
-    echo "=== Checking libSFCGAL.a contents for ${sdk_name} ${arch} ==="
-    local lib_a
-    lib_a=$(find "$build_dir" -name "libSFCGAL.a" | head -1)
-    if [ -n "$lib_a" ]; then
-        echo "  Archive: $lib_a"
-
-        # Extract Sphere.cpp.o and dump ALL its symbols
-        local extract_dir="$build_dir/nm-debug"
-        mkdir -p "$extract_dir"
-        (cd "$extract_dir" && ar x "$lib_a" Sphere.cpp.o 2>/dev/null) || true
-
-        if [ -f "$extract_dir/Sphere.cpp.o" ]; then
-            echo "  --- ALL defined symbols (T/t) in Sphere.cpp.o ---"
-            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep -E " [Tt] " | head -20 || echo "  (none)"
-
-            echo "  --- ALL undefined symbols (U) in Sphere.cpp.o ---"
-            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep " U " | grep -i "sfcgal\|sphere\|cylinder" | head -10 || echo "  (none matching SFCGAL/Sphere/Cylinder)"
-
-            echo "  --- Looking for ANY SFCGAL:: symbols in Sphere.cpp.o ---"
-            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "SFCGAL" | head -20 || echo "  NO SFCGAL symbols at all in Sphere.cpp.o"
-
-            echo "  --- File size of Sphere.cpp.o ---"
-            ls -la "$extract_dir/Sphere.cpp.o"
-        else
-            echo "  WARNING: Could not extract Sphere.cpp.o from archive"
-        fi
-
-        # Also check what buffer3D.cpp.o expects
-        (cd "$extract_dir" && ar x "$lib_a" buffer3D.cpp.o 2>/dev/null) || true
-        if [ -f "$extract_dir/buffer3D.cpp.o" ]; then
-            echo "  --- Undefined SFCGAL::Sphere/Cylinder symbols needed by buffer3D.cpp.o ---"
-            nm "$extract_dir/buffer3D.cpp.o" 2>/dev/null | grep " U " | grep -iE "sphere|cylinder" | head -10 || echo "  (none)"
-        fi
-
-        # Check the CMake compile command for Sphere.cpp
-        echo "  --- CMake compile command for Sphere.cpp ---"
-        find "$build_dir" -name "*.make" -o -name "compile_commands.json" | head -3
-        grep -r "Sphere.cpp" "$build_dir/src/CMakeFiles/SFCGAL.dir/flags.make" 2>/dev/null || true
-        grep "Sphere.cpp" "$build_dir/compile_commands.json" 2>/dev/null | head -5 || true
-    else
-        echo "  WARNING: libSFCGAL.a not found in build dir"
-    fi
 
     echo "=== Installing SFCGAL for ${sdk_name} ${arch} ==="
     cmake --install "$build_dir" > /dev/null 2>&1

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -123,6 +123,12 @@ BOOST_ROOT="$WORK_DIR/boost_${BOOST_VERSION_UNDERSCORE}"
 sed -i.bak 's/^set(Boost_USE_STATIC_LIBS OFF)/#set(Boost_USE_STATIC_LIBS OFF)  # patched for iOS static build/' \
     "$SFCGAL_SRC/CMakeLists.txt"
 
+# Debug: inject a diagnostic message into src/CMakeLists.txt so we can see
+# exactly which sources GLOB_RECURSE picks up during cross-compilation.
+sed -i.bak2 '/^file( GLOB_RECURSE SFCGAL_SOURCES/a\
+message(STATUS "SFCGAL_SOURCES (glob result): ${SFCGAL_SOURCES}")
+' "$SFCGAL_SRC/src/CMakeLists.txt"
+
 # =============================================================================
 # Build required Boost libraries for iOS
 # =============================================================================
@@ -268,10 +274,20 @@ build_sfcgal() {
         -DMPFR_LIBRARIES="$mpfr_prefix/lib/libmpfr.a" \
         -DCMAKE_CXX_STANDARD=17 \
         -Wno-dev \
-        > /dev/null 2>&1
+        2>&1 | grep -E "(SFCGAL_SOURCES|primitive3d|Sphere|Cylinder|STATUS)" || true
 
     echo "=== Building SFCGAL for ${sdk_name} ${arch} ==="
     cmake --build "$build_dir" --config Release -j"$NCPU" 2>&1 | tail -5
+
+    echo "=== Checking libSFCGAL.a contents for ${sdk_name} ${arch} ==="
+    if [ -f "$build_dir/lib/libSFCGAL.a" ]; then
+        ar t "$build_dir/lib/libSFCGAL.a" | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found in archive"
+    elif [ -f "$build_dir/libSFCGAL.a" ]; then
+        ar t "$build_dir/libSFCGAL.a" | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found in archive"
+    else
+        echo "  Searching for libSFCGAL.a..."
+        find "$build_dir" -name "libSFCGAL.a" -exec ar t {} \; 2>/dev/null | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found"
+    fi
 
     echo "=== Installing SFCGAL for ${sdk_name} ${arch} ==="
     cmake --install "$build_dir" > /dev/null 2>&1

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -290,16 +290,40 @@ build_sfcgal() {
     lib_a=$(find "$build_dir" -name "libSFCGAL.a" | head -1)
     if [ -n "$lib_a" ]; then
         echo "  Archive: $lib_a"
-        ar t "$lib_a" | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found in archive"
 
-        echo "  --- Symbols DEFINED in Sphere.cpp.o (T = defined, U = undefined) ---"
-        nm "$lib_a" 2>/dev/null | grep -i "sphere" | grep -E "^[0-9a-f]* [Tt]" | head -10 || echo "  No defined Sphere symbols found"
+        # Extract Sphere.cpp.o and dump ALL its symbols
+        local extract_dir="$build_dir/nm-debug"
+        mkdir -p "$extract_dir"
+        (cd "$extract_dir" && ar x "$lib_a" Sphere.cpp.o 2>/dev/null) || true
 
-        echo "  --- Symbols UNDEFINED referencing Sphere in buffer3D.cpp.o ---"
-        nm "$lib_a" 2>/dev/null | grep "buffer3D" -A 1000 | grep -i "sphere" | grep " U " | head -10 || true
+        if [ -f "$extract_dir/Sphere.cpp.o" ]; then
+            echo "  --- ALL defined symbols (T/t) in Sphere.cpp.o ---"
+            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep -E " [Tt] " | head -20 || echo "  (none)"
 
-        echo "  --- All Sphere/Cylinder symbols in archive ---"
-        nm "$lib_a" 2>/dev/null | grep -iE "(sphere|cylinder)" | head -20 || echo "  No Sphere/Cylinder symbols at all"
+            echo "  --- ALL undefined symbols (U) in Sphere.cpp.o ---"
+            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep " U " | grep -i "sfcgal\|sphere\|cylinder" | head -10 || echo "  (none matching SFCGAL/Sphere/Cylinder)"
+
+            echo "  --- Looking for ANY SFCGAL:: symbols in Sphere.cpp.o ---"
+            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "SFCGAL" | head -20 || echo "  NO SFCGAL symbols at all in Sphere.cpp.o"
+
+            echo "  --- File size of Sphere.cpp.o ---"
+            ls -la "$extract_dir/Sphere.cpp.o"
+        else
+            echo "  WARNING: Could not extract Sphere.cpp.o from archive"
+        fi
+
+        # Also check what buffer3D.cpp.o expects
+        (cd "$extract_dir" && ar x "$lib_a" buffer3D.cpp.o 2>/dev/null) || true
+        if [ -f "$extract_dir/buffer3D.cpp.o" ]; then
+            echo "  --- Undefined SFCGAL::Sphere/Cylinder symbols needed by buffer3D.cpp.o ---"
+            nm "$extract_dir/buffer3D.cpp.o" 2>/dev/null | grep " U " | grep -iE "sphere|cylinder" | head -10 || echo "  (none)"
+        fi
+
+        # Check the CMake compile command for Sphere.cpp
+        echo "  --- CMake compile command for Sphere.cpp ---"
+        find "$build_dir" -name "*.make" -o -name "compile_commands.json" | head -3
+        grep -r "Sphere.cpp" "$build_dir/src/CMakeFiles/SFCGAL.dir/flags.make" 2>/dev/null || true
+        grep "Sphere.cpp" "$build_dir/compile_commands.json" 2>/dev/null | head -5 || true
     else
         echo "  WARNING: libSFCGAL.a not found in build dir"
     fi

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -125,20 +125,21 @@ BOOST_ROOT="$WORK_DIR/boost_${BOOST_VERSION_UNDERSCORE}"
 sed -i.bak 's/^set(Boost_USE_STATIC_LIBS OFF)/#set(Boost_USE_STATIC_LIBS OFF)  # patched for iOS static build/' \
     "$SFCGAL_SRC/CMakeLists.txt"
 
-# Apple Clang at -O2 inlines the Sphere/Cylinder constructors (which have
-# empty bodies with only member-initializer lists) and never emits an
-# out-of-line symbol. buffer3D.cpp references them as external symbols,
-# causing an undefined-symbol link error. Fix: disable inlining for the
-# primitive3d source files so the constructors are always emitted.
+# Workaround: Apple Clang cross-compiling for iOS does not emit ANY non-template
+# symbols from src/primitive3d/*.cpp (Sphere, Cylinder). All methods — not just
+# constructors — are missing from the .o files. Force -O0 and -fstandalone-debug
+# for these files and print the actual compile command for diagnosis.
 if [ -d "$SFCGAL_SRC/src/primitive3d" ]; then
-    echo "=== Patching src/CMakeLists.txt: disable inlining for primitive3d ==="
+    echo "=== Patching src/CMakeLists.txt: force symbol emission for primitive3d ==="
     cat >> "$SFCGAL_SRC/src/CMakeLists.txt" << 'PATCH'
 
-# Patched for iOS cross-compilation: Apple Clang at -O2 inlines Sphere/Cylinder
-# constructors and never emits out-of-line symbols, breaking the link.
+# Patched for iOS cross-compilation: force primitive3d symbol emission
 file( GLOB _PRIMITIVE3D_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/primitive3d/*.cpp" )
+message(STATUS "primitive3d sources: ${_PRIMITIVE3D_SOURCES}")
 if(_PRIMITIVE3D_SOURCES)
-    set_source_files_properties(${_PRIMITIVE3D_SOURCES} PROPERTIES COMPILE_OPTIONS "-fno-inline-functions")
+    set_source_files_properties(${_PRIMITIVE3D_SOURCES}
+        PROPERTIES COMPILE_OPTIONS "-O0;-fno-inline;-fstandalone-debug"
+    )
 endif()
 PATCH
 fi
@@ -287,11 +288,40 @@ build_sfcgal() {
         -DMPFR_INCLUDE_DIR="$mpfr_prefix/include" \
         -DMPFR_LIBRARIES="$mpfr_prefix/lib/libmpfr.a" \
         -DCMAKE_CXX_STANDARD=17 \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -Wno-dev \
-        > /dev/null 2>&1
+        2>&1 | grep -E "(primitive3d|SFCGAL_SOURCES.*primitive)" || true
 
     echo "=== Building SFCGAL for ${sdk_name} ${arch} ==="
     cmake --build "$build_dir" --config Release -j"$NCPU" 2>&1 | tail -5
+
+    # Show the actual compile command used for Sphere.cpp
+    echo "=== Compile command for Sphere.cpp (${sdk_name} ${arch}) ==="
+    if [ -f "$build_dir/compile_commands.json" ]; then
+        python3 -c "
+import json
+with open('$build_dir/compile_commands.json') as f:
+    for entry in json.load(f):
+        if 'Sphere.cpp' in entry.get('file',''):
+            print(entry['command'][:500])
+            break
+" 2>/dev/null || echo "  (could not parse compile_commands.json)"
+    fi
+
+    # Quick nm check on first arch only
+    if [ "$arch" = "arm64" ] && [ "$sdk_name" = "iphoneos" ]; then
+        local lib_a
+        lib_a=$(find "$build_dir" -name "libSFCGAL.a" | head -1)
+        if [ -n "$lib_a" ]; then
+            local extract_dir="$build_dir/nm-check"
+            mkdir -p "$extract_dir"
+            (cd "$extract_dir" && ar x "$lib_a" Sphere.cpp.o 2>/dev/null) || true
+            if [ -f "$extract_dir/Sphere.cpp.o" ]; then
+                echo "=== SFCGAL:: symbols in Sphere.cpp.o ==="
+                nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "6SFCGAL" | head -15 || echo "  NONE"
+            fi
+        fi
+    fi
 
     echo "=== Installing SFCGAL for ${sdk_name} ${arch} ==="
     cmake --install "$build_dir" > /dev/null 2>&1

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -27,8 +27,8 @@
 # Patches applied to SFCGAL source:
 #   - Removes hard-coded set(Boost_USE_STATIC_LIBS OFF) so the cache variable
 #     from our -DBoost_USE_STATIC_LIBS=ON takes effect.
-#   - Disables inlining for src/primitive3d/*.cpp (Sphere, Cylinder) to force
-#     Apple Clang to emit out-of-line constructor symbols at -O2.
+#   - Defines CGAL_DO_NOT_USE_BOOST_MP to ensure consistent type mangling
+#     across all translation units (prevents Gmpq vs boost::multiprecision mismatch).
 
 set -euo pipefail
 
@@ -125,24 +125,21 @@ BOOST_ROOT="$WORK_DIR/boost_${BOOST_VERSION_UNDERSCORE}"
 sed -i.bak 's/^set(Boost_USE_STATIC_LIBS OFF)/#set(Boost_USE_STATIC_LIBS OFF)  # patched for iOS static build/' \
     "$SFCGAL_SRC/CMakeLists.txt"
 
-# Workaround: Apple Clang cross-compiling for iOS does not emit ANY non-template
-# symbols from src/primitive3d/*.cpp (Sphere, Cylinder). All methods — not just
-# constructors — are missing from the .o files. Force -O0 and -fstandalone-debug
-# for these files and print the actual compile command for diagnosis.
-if [ -d "$SFCGAL_SRC/src/primitive3d" ]; then
-    echo "=== Patching src/CMakeLists.txt: force symbol emission for primitive3d ==="
-    cat >> "$SFCGAL_SRC/src/CMakeLists.txt" << 'PATCH'
+# CGAL type mismatch fix: When CGAL detects GMP at configure time, some
+# translation units see Kernel::FT as CGAL::Lazy_exact_nt<CGAL::Gmpq> while
+# others (compiled with different optimization or include order) see it as
+# CGAL::Lazy_exact_nt<boost::multiprecision::number<gmp_rational>>. This causes
+# linker failures because the mangled symbols differ.
+#
+# Fix: ensure CGAL uses its own Gmpq wrapper consistently by defining
+# CGAL_DO_NOT_USE_BOOST_MP, which prevents CGAL from using Boost.Multiprecision
+# wrappers for GMP types.
+echo "=== Patching: force consistent CGAL type resolution ==="
+cat >> "$SFCGAL_SRC/src/CMakeLists.txt" << 'PATCH'
 
-# Patched for iOS cross-compilation: force primitive3d symbol emission
-file( GLOB _PRIMITIVE3D_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/primitive3d/*.cpp" )
-message(STATUS "primitive3d sources: ${_PRIMITIVE3D_SOURCES}")
-if(_PRIMITIVE3D_SOURCES)
-    set_source_files_properties(${_PRIMITIVE3D_SOURCES}
-        PROPERTIES COMPILE_OPTIONS "-O0;-fno-inline;-fstandalone-debug"
-    )
-endif()
+# Patched for iOS: ensure consistent CGAL::Gmpq usage across all translation units
+target_compile_definitions(SFCGAL PRIVATE CGAL_DO_NOT_USE_BOOST_MP)
 PATCH
-fi
 
 # =============================================================================
 # Build required Boost libraries for iOS
@@ -288,57 +285,14 @@ build_sfcgal() {
         -DMPFR_INCLUDE_DIR="$mpfr_prefix/include" \
         -DMPFR_LIBRARIES="$mpfr_prefix/lib/libmpfr.a" \
         -DCMAKE_CXX_STANDARD=17 \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -Wno-dev \
-        2>&1 | grep -E "(primitive3d|SFCGAL_SOURCES.*primitive)" || true
+        > /dev/null 2>&1
 
     echo "=== Building SFCGAL for ${sdk_name} ${arch} ==="
     cmake --build "$build_dir" --config Release -j"$NCPU" 2>&1 | tail -5
 
-    # Show the actual compile command used for Sphere.cpp
-    echo "=== Compile command for Sphere.cpp (${sdk_name} ${arch}) ==="
-    if [ -f "$build_dir/compile_commands.json" ]; then
-        python3 -c "
-import json
-with open('$build_dir/compile_commands.json') as f:
-    for entry in json.load(f):
-        if 'Sphere.cpp' in entry.get('file',''):
-            print(entry['command'][:500])
-            break
-" 2>/dev/null || echo "  (could not parse compile_commands.json)"
-    fi
-
-    # Check for Sphere/Cylinder constructor symbols specifically
-    if [ "$arch" = "arm64" ] && [ "$sdk_name" = "iphoneos" ]; then
-        local lib_a
-        lib_a=$(find "$build_dir" -name "libSFCGAL.a" | head -1)
-        if [ -n "$lib_a" ]; then
-            local extract_dir="$build_dir/nm-check"
-            mkdir -p "$extract_dir"
-            (cd "$extract_dir" && ar x "$lib_a" Sphere.cpp.o 2>/dev/null) || true
-            (cd "$extract_dir" && ar x "$lib_a" Cylinder.cpp.o 2>/dev/null) || true
-
-            echo "=== All SFCGAL::Sphere symbols (no limit) ==="
-            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "6SFCGAL6Sphere" || echo "  NONE"
-
-            echo "=== All SFCGAL::Cylinder symbols (no limit) ==="
-            nm "$extract_dir/Cylinder.cpp.o" 2>/dev/null | grep "6SFCGAL8Cylinder" || echo "  NONE"
-
-            echo "=== Specifically looking for constructors (C1/C2) ==="
-            nm "$extract_dir/Sphere.cpp.o" 2>/dev/null | grep "6SphereC" || echo "  No Sphere constructor"
-            nm "$extract_dir/Cylinder.cpp.o" 2>/dev/null | grep "8CylinderC" || echo "  No Cylinder constructor"
-
-        fi
-    fi
-
     echo "=== Installing SFCGAL for ${sdk_name} ${arch} ==="
     cmake --install "$build_dir" > /dev/null 2>&1
-
-    # Verify installed library has the constructors
-    if [ "$arch" = "arm64" ] && [ "$sdk_name" = "iphoneos" ]; then
-        echo "=== Constructors in INSTALLED library ==="
-        nm "$prefix/lib/libSFCGAL.a" 2>/dev/null | grep -E "6SphereC|8CylinderC" | head -5 || echo "  MISSING in installed lib"
-    fi
 }
 
 mkdir -p "$OUTPUT_DIR"

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -129,6 +129,12 @@ sed -i.bak2 '/^file( GLOB_RECURSE SFCGAL_SOURCES/a\
 message(STATUS "SFCGAL_SOURCES (glob result): ${SFCGAL_SOURCES}")
 ' "$SFCGAL_SRC/src/CMakeLists.txt"
 
+# Debug: check how SFCGAL_API is defined (visibility issue?)
+echo "=== Checking SFCGAL_API / export macro ==="
+grep -n "SFCGAL_API\|visibility\|SFCGAL_BUILD_SHARED\|SFCGAL_USE_STATIC" "$SFCGAL_SRC/src/export.h" || echo "  export.h not found at expected path"
+echo "=== Checking if Sphere.h uses SFCGAL_API ==="
+head -30 "$SFCGAL_SRC/src/primitive3d/Sphere.h" 2>/dev/null || echo "  Sphere.h not found"
+
 # =============================================================================
 # Build required Boost libraries for iOS
 # =============================================================================
@@ -280,13 +286,22 @@ build_sfcgal() {
     cmake --build "$build_dir" --config Release -j"$NCPU" 2>&1 | tail -5
 
     echo "=== Checking libSFCGAL.a contents for ${sdk_name} ${arch} ==="
-    if [ -f "$build_dir/lib/libSFCGAL.a" ]; then
-        ar t "$build_dir/lib/libSFCGAL.a" | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found in archive"
-    elif [ -f "$build_dir/libSFCGAL.a" ]; then
-        ar t "$build_dir/libSFCGAL.a" | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found in archive"
+    local lib_a
+    lib_a=$(find "$build_dir" -name "libSFCGAL.a" | head -1)
+    if [ -n "$lib_a" ]; then
+        echo "  Archive: $lib_a"
+        ar t "$lib_a" | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found in archive"
+
+        echo "  --- Symbols DEFINED in Sphere.cpp.o (T = defined, U = undefined) ---"
+        nm "$lib_a" 2>/dev/null | grep -i "sphere" | grep -E "^[0-9a-f]* [Tt]" | head -10 || echo "  No defined Sphere symbols found"
+
+        echo "  --- Symbols UNDEFINED referencing Sphere in buffer3D.cpp.o ---"
+        nm "$lib_a" 2>/dev/null | grep "buffer3D" -A 1000 | grep -i "sphere" | grep " U " | head -10 || true
+
+        echo "  --- All Sphere/Cylinder symbols in archive ---"
+        nm "$lib_a" 2>/dev/null | grep -iE "(sphere|cylinder)" | head -20 || echo "  No Sphere/Cylinder symbols at all"
     else
-        echo "  Searching for libSFCGAL.a..."
-        find "$build_dir" -name "libSFCGAL.a" -exec ar t {} \; 2>/dev/null | grep -iE "(sphere|cylinder)" || echo "  WARNING: No Sphere/Cylinder objects found"
+        echo "  WARNING: libSFCGAL.a not found in build dir"
     fi
 
     echo "=== Installing SFCGAL for ${sdk_name} ${arch} ==="

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+#
+# build-sfcgal-ios.sh — Cross-compile SFCGAL for iOS device and simulator
+#
+# Downloads CGAL (header-only), Boost (builds thread/system/serialization),
+# then builds SFCGAL as a static library using CMake with an iOS toolchain.
+#
+# Produces:
+#   $OUTPUT_DIR/ios-arm64/          — device (arm64, platform IOS)
+#   $OUTPUT_DIR/simulator-arm64/    — simulator Apple Silicon (arm64, platform IOS_SIMULATOR)
+#   $OUTPUT_DIR/simulator-x86_64/   — simulator Intel (x86_64, platform IOS_SIMULATOR)
+#   $OUTPUT_DIR/simulator-fat/      — merged simulator (arm64 + x86_64)
+#
+# Usage:
+#   ./scripts/build-sfcgal-ios.sh <gmp_dir> <mpfr_dir> [output_dir]
+#
+#   gmp_dir:    path to GMP cross-compiled output (from build-gmp-ios.sh)
+#   mpfr_dir:   path to MPFR cross-compiled output (from build-mpfr-ios.sh)
+#   output_dir: where to place SFCGAL builds (default: ./sfcgal-ios-build)
+#
+# Requirements:
+#   - Xcode (not just Command Line Tools) for iOS SDKs
+#   - CMake 3.21+
+#   - Cross-compiled GMP and MPFR (run build-gmp-ios.sh and build-mpfr-ios.sh first)
+#   - curl, tar, lipo, otool
+#
+# Patches applied to SFCGAL source:
+#   - Removes hard-coded set(Boost_USE_STATIC_LIBS OFF) so the cache variable
+#     from our -DBoost_USE_STATIC_LIBS=ON takes effect.
+
+set -euo pipefail
+
+SFCGAL_VERSION="2.0.0"
+SFCGAL_URL="https://gitlab.com/sfcgal/SFCGAL/-/archive/v${SFCGAL_VERSION}/SFCGAL-v${SFCGAL_VERSION}.tar.gz"
+CGAL_VERSION="6.0.1"
+CGAL_URL="https://github.com/CGAL/cgal/releases/download/v${CGAL_VERSION}/CGAL-${CGAL_VERSION}.tar.xz"
+BOOST_VERSION="1.87.0"
+BOOST_VERSION_UNDERSCORE="1_87_0"
+BOOST_URL="https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
+IOS_MIN_VERSION="15.0"
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <gmp_dir> <mpfr_dir> [output_dir]"
+    echo "  gmp_dir:    path to GMP cross-compiled output (from build-gmp-ios.sh)"
+    echo "  mpfr_dir:   path to MPFR cross-compiled output (from build-mpfr-ios.sh)"
+    echo "  output_dir: where to place SFCGAL builds (default: ./sfcgal-ios-build)"
+    exit 1
+fi
+
+GMP_DIR="$(cd "$1" && pwd)"
+MPFR_DIR="$(cd "$2" && pwd)"
+OUTPUT_DIR="$(mkdir -p "${3:-$(pwd)/sfcgal-ios-build}" && cd "${3:-$(pwd)/sfcgal-ios-build}" && pwd)"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+NCPU=$(sysctl -n hw.ncpu)
+
+# Validate GMP and MPFR builds exist
+for variant in ios-arm64 simulator-arm64 simulator-x86_64; do
+    if [ ! -f "$GMP_DIR/$variant/lib/libgmp.a" ]; then
+        echo "ERROR: Missing GMP build at $GMP_DIR/$variant/lib/libgmp.a"
+        echo "Run build-gmp-ios.sh first."
+        exit 1
+    fi
+    if [ ! -f "$MPFR_DIR/$variant/lib/libmpfr.a" ]; then
+        echo "ERROR: Missing MPFR build at $MPFR_DIR/$variant/lib/libmpfr.a"
+        echo "Run build-mpfr-ios.sh first."
+        exit 1
+    fi
+done
+
+if ! command -v cmake &> /dev/null; then
+    echo "ERROR: cmake not found. Install with: brew install cmake"
+    exit 1
+fi
+
+# =============================================================================
+# Download dependencies
+# =============================================================================
+
+echo "=== Downloading SFCGAL ${SFCGAL_VERSION} ==="
+curl -sL "$SFCGAL_URL" -o "$WORK_DIR/sfcgal.tar.gz"
+tar xf "$WORK_DIR/sfcgal.tar.gz" -C "$WORK_DIR"
+SFCGAL_SRC="$WORK_DIR/SFCGAL-v${SFCGAL_VERSION}"
+
+echo "=== Downloading CGAL ${CGAL_VERSION} (headers only) ==="
+curl -sL "$CGAL_URL" -o "$WORK_DIR/cgal.tar.xz"
+tar xf "$WORK_DIR/cgal.tar.xz" -C "$WORK_DIR"
+CGAL_DIR="$WORK_DIR/CGAL-${CGAL_VERSION}"
+
+echo "=== Downloading Boost ${BOOST_VERSION} ==="
+curl -sL "$BOOST_URL" -o "$WORK_DIR/boost.tar.gz"
+tar xf "$WORK_DIR/boost.tar.gz" -C "$WORK_DIR"
+BOOST_ROOT="$WORK_DIR/boost_${BOOST_VERSION_UNDERSCORE}"
+
+# =============================================================================
+# Patch SFCGAL source
+# =============================================================================
+
+# SFCGAL's CMakeLists.txt line 92 hard-codes set(Boost_USE_STATIC_LIBS OFF),
+# which overrides our -DBoost_USE_STATIC_LIBS=ON cache variable. Remove it
+# so the option() on line 99 respects the cache.
+sed -i.bak 's/^set(Boost_USE_STATIC_LIBS OFF)/#set(Boost_USE_STATIC_LIBS OFF)  # patched for iOS static build/' \
+    "$SFCGAL_SRC/CMakeLists.txt"
+
+# =============================================================================
+# Build required Boost libraries for iOS
+# =============================================================================
+# SFCGAL needs Boost.Thread, Boost.System, and Boost.Serialization (compiled).
+# We build them with b2, which also generates native CMake config files.
+
+echo "=== Bootstrapping Boost b2 ==="
+(cd "$BOOST_ROOT" && ./bootstrap.sh --with-libraries=thread,system,serialization > /dev/null 2>&1)
+
+# Build Boost for a single iOS target using b2
+# Arguments: $1=sdk_name $2=arch $3=target_triple $4=variant_name
+build_boost() {
+    local sdk_name="$1"
+    local arch="$2"
+    local target_triple="$3"
+    local variant_name="$4"
+
+    local sdk_path
+    sdk_path=$(xcrun --sdk "$sdk_name" --show-sdk-path)
+    local cxx
+    cxx=$(xcrun --sdk "$sdk_name" --find clang++)
+
+    local boost_install="$WORK_DIR/boost-${variant_name}"
+
+    echo "=== Building Boost for ${sdk_name} ${arch} ===" >&2
+
+    local jam_file="$WORK_DIR/user-config-${variant_name}.jam"
+    cat > "$jam_file" << JAMEOF
+using clang : ios
+    : ${cxx}
+    : <compileflags>"-arch ${arch} -isysroot ${sdk_path} -target ${target_triple} -std=c++17 -DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS"
+      <linkflags>"-arch ${arch} -isysroot ${sdk_path} -target ${target_triple}"
+    ;
+JAMEOF
+
+    (
+        cd "$BOOST_ROOT"
+        ./b2 \
+            --user-config="$jam_file" \
+            --prefix="$boost_install" \
+            --with-thread \
+            --with-system \
+            --with-serialization \
+            toolset=clang-ios \
+            link=static \
+            threading=multi \
+            variant=release \
+            target-os=iphone \
+            architecture=arm \
+            -j"$NCPU" \
+            install \
+            > /dev/null 2>&1
+    )
+
+    echo "$boost_install"
+}
+
+BOOST_IOS_ARM64=$(build_boost iphoneos arm64 "arm64-apple-ios${IOS_MIN_VERSION}" ios-arm64)
+BOOST_SIM_ARM64=$(build_boost iphonesimulator arm64 "arm64-apple-ios${IOS_MIN_VERSION}-simulator" simulator-arm64)
+BOOST_SIM_X86=$(build_boost iphonesimulator x86_64 "x86_64-apple-ios${IOS_MIN_VERSION}-simulator" simulator-x86_64)
+
+# =============================================================================
+# Generate CMake toolchain file
+# =============================================================================
+
+generate_toolchain() {
+    local sdk_name="$1"
+    local arch="$2"
+    local target_triple="$3"
+    local toolchain_file="$4"
+
+    local sdk_path
+    sdk_path=$(xcrun --sdk "$sdk_name" --show-sdk-path)
+    local cc
+    cc=$(xcrun --sdk "$sdk_name" --find clang)
+    local cxx
+    cxx=$(xcrun --sdk "$sdk_name" --find clang++)
+
+    cat > "$toolchain_file" << TCEOF
+# Auto-generated iOS toolchain for ${sdk_name} ${arch}
+set(CMAKE_SYSTEM_NAME iOS)
+set(CMAKE_OSX_ARCHITECTURES ${arch})
+set(CMAKE_OSX_DEPLOYMENT_TARGET ${IOS_MIN_VERSION})
+set(CMAKE_OSX_SYSROOT ${sdk_path})
+
+set(CMAKE_C_COMPILER ${cc})
+set(CMAKE_CXX_COMPILER ${cxx})
+
+# Skip compiler checks — cross-compiling, can't run test binaries
+set(CMAKE_C_COMPILER_WORKS TRUE)
+set(CMAKE_CXX_COMPILER_WORKS TRUE)
+
+set(CMAKE_C_FLAGS_INIT "-arch ${arch} -target ${target_triple}")
+set(CMAKE_CXX_FLAGS_INIT "-arch ${arch} -target ${target_triple}")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-arch ${arch} -target ${target_triple}")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+# BOTH allows CMake to find our cross-compiled packages outside the sysroot
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
+TCEOF
+}
+
+# =============================================================================
+# Build SFCGAL for a single target
+# =============================================================================
+# Arguments: $1=sdk_name $2=arch $3=target_triple $4=install_prefix
+#            $5=gmp_prefix $6=mpfr_prefix $7=boost_prefix
+build_sfcgal() {
+    local sdk_name="$1"
+    local arch="$2"
+    local target_triple="$3"
+    local prefix="$4"
+    local gmp_prefix="$5"
+    local mpfr_prefix="$6"
+    local boost_prefix="$7"
+
+    local build_dir="$WORK_DIR/build-${sdk_name}-${arch}"
+    mkdir -p "$build_dir"
+
+    local toolchain_file="$build_dir/ios-toolchain.cmake"
+    generate_toolchain "$sdk_name" "$arch" "$target_triple" "$toolchain_file"
+
+    echo "=== Configuring SFCGAL for ${sdk_name} ${arch} ==="
+    cmake -S "$SFCGAL_SRC" -B "$build_dir" \
+        -DCMAKE_TOOLCHAIN_FILE="$toolchain_file" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$prefix" \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DSFCGAL_USE_STATIC_LIBS=ON \
+        -DSFCGAL_BUILD_TESTS=OFF \
+        -DSFCGAL_BUILD_EXAMPLES=OFF \
+        -DSFCGAL_BUILD_BENCH=OFF \
+        -DCGAL_DIR="$CGAL_DIR/lib/cmake/CGAL" \
+        -DCMAKE_PREFIX_PATH="$boost_prefix" \
+        -DBoost_USE_STATIC_LIBS=ON \
+        -DCGAL_Boost_USE_STATIC_LIBS=ON \
+        -DBoost_NO_SYSTEM_PATHS=ON \
+        -DGMP_INCLUDE_DIR="$gmp_prefix/include" \
+        -DGMP_LIBRARIES="$gmp_prefix/lib/libgmp.a" \
+        -DMPFR_INCLUDE_DIR="$mpfr_prefix/include" \
+        -DMPFR_LIBRARIES="$mpfr_prefix/lib/libmpfr.a" \
+        -DCMAKE_CXX_STANDARD=17 \
+        -Wno-dev \
+        > /dev/null 2>&1
+
+    echo "=== Building SFCGAL for ${sdk_name} ${arch} ==="
+    cmake --build "$build_dir" --config Release -j"$NCPU" 2>&1 | tail -5
+
+    echo "=== Installing SFCGAL for ${sdk_name} ${arch} ==="
+    cmake --install "$build_dir" > /dev/null 2>&1
+}
+
+mkdir -p "$OUTPUT_DIR"
+
+# 1. iOS device (arm64)
+build_sfcgal \
+    iphoneos \
+    arm64 \
+    "arm64-apple-ios${IOS_MIN_VERSION}" \
+    "$OUTPUT_DIR/ios-arm64" \
+    "$GMP_DIR/ios-arm64" \
+    "$MPFR_DIR/ios-arm64" \
+    "$BOOST_IOS_ARM64"
+
+# 2. iOS Simulator (arm64, Apple Silicon)
+build_sfcgal \
+    iphonesimulator \
+    arm64 \
+    "arm64-apple-ios${IOS_MIN_VERSION}-simulator" \
+    "$OUTPUT_DIR/simulator-arm64" \
+    "$GMP_DIR/simulator-arm64" \
+    "$MPFR_DIR/simulator-arm64" \
+    "$BOOST_SIM_ARM64"
+
+# 3. iOS Simulator (x86_64, Intel)
+build_sfcgal \
+    iphonesimulator \
+    x86_64 \
+    "x86_64-apple-ios${IOS_MIN_VERSION}-simulator" \
+    "$OUTPUT_DIR/simulator-x86_64" \
+    "$GMP_DIR/simulator-x86_64" \
+    "$MPFR_DIR/simulator-x86_64" \
+    "$BOOST_SIM_X86"
+
+# =============================================================================
+# Create fat simulator library
+# =============================================================================
+
+echo "=== Creating fat simulator library ==="
+mkdir -p "$OUTPUT_DIR/simulator-fat/lib"
+cp -R "$OUTPUT_DIR/simulator-arm64/include" "$OUTPUT_DIR/simulator-fat/include"
+lipo -create \
+    "$OUTPUT_DIR/simulator-arm64/lib/libSFCGAL.a" \
+    "$OUTPUT_DIR/simulator-x86_64/lib/libSFCGAL.a" \
+    -output "$OUTPUT_DIR/simulator-fat/lib/libSFCGAL.a"
+
+# =============================================================================
+# Verify all outputs
+# =============================================================================
+
+echo ""
+echo "=== Verification ==="
+verify_lib() {
+    local lib="$1"
+    local expected_platform="$2"
+    local label="$3"
+
+    local arch
+    arch=$(lipo -info "$lib" 2>&1)
+    local platform
+    platform=$(otool -l "$lib" 2>&1 | grep -A2 LC_BUILD_VERSION | grep platform | head -1 | awk '{print $2}')
+
+    local status="OK"
+    if [ "$platform" != "$expected_platform" ]; then
+        status="FAIL (expected platform $expected_platform, got $platform)"
+    fi
+
+    echo "  ${label}: ${arch} | platform=${platform} | ${status}"
+}
+
+# platform 2 = IOS, platform 7 = IOS_SIMULATOR
+verify_lib "$OUTPUT_DIR/ios-arm64/lib/libSFCGAL.a" "2" "iOS device arm64"
+verify_lib "$OUTPUT_DIR/simulator-arm64/lib/libSFCGAL.a" "7" "Simulator arm64"
+verify_lib "$OUTPUT_DIR/simulator-x86_64/lib/libSFCGAL.a" "7" "Simulator x86_64"
+
+echo "  Simulator fat: $(lipo -info "$OUTPUT_DIR/simulator-fat/lib/libSFCGAL.a")"
+
+# Verify C API header is present
+echo ""
+echo "=== C API header check ==="
+if [ -f "$OUTPUT_DIR/ios-arm64/include/SFCGAL/capi/sfcgal_c.h" ]; then
+    echo "  sfcgal_c.h: OK"
+else
+    echo "  sfcgal_c.h: MISSING"
+    echo "  Searching for sfcgal_c.h..."
+    find "$OUTPUT_DIR/ios-arm64/include" -name "sfcgal_c.h" 2>/dev/null || echo "  Not found in install prefix"
+fi
+
+# =============================================================================
+# Link test
+# =============================================================================
+
+echo ""
+echo "=== Link test ==="
+TEST_DIR="$WORK_DIR/link-test"
+mkdir -p "$TEST_DIR"
+
+cat > "$TEST_DIR/test_sfcgal.c" << 'CEOF'
+#include <SFCGAL/capi/sfcgal_c.h>
+#include <stdio.h>
+
+int main(void) {
+    sfcgal_init();
+    const char* version = sfcgal_version();
+    printf("SFCGAL %s linked OK\n", version);
+    return 0;
+}
+CEOF
+
+IOS_SDK=$(xcrun --sdk iphoneos --show-sdk-path)
+IOS_CXX=$(xcrun --sdk iphoneos --find clang++)
+
+# SFCGAL is C++, link with clang++ and all static dependencies
+"$IOS_CXX" \
+    -arch arm64 \
+    -isysroot "$IOS_SDK" \
+    -target "arm64-apple-ios${IOS_MIN_VERSION}" \
+    -I"$OUTPUT_DIR/ios-arm64/include" \
+    -I"$GMP_DIR/ios-arm64/include" \
+    -I"$MPFR_DIR/ios-arm64/include" \
+    -L"$OUTPUT_DIR/ios-arm64/lib" \
+    -L"$GMP_DIR/ios-arm64/lib" \
+    -L"$MPFR_DIR/ios-arm64/lib" \
+    -L"$BOOST_IOS_ARM64/lib" \
+    -lSFCGAL -lboost_serialization -lboost_thread -lboost_system \
+    -lmpfr -lgmp -lc++ \
+    -o "$TEST_DIR/test_sfcgal" \
+    "$TEST_DIR/test_sfcgal.c" \
+    2>&1
+
+if [ $? -eq 0 ]; then
+    echo "  Link test: OK"
+    file "$TEST_DIR/test_sfcgal"
+else
+    echo "  Link test: FAIL"
+    exit 1
+fi
+
+echo ""
+echo "=== Build complete ==="
+echo "Output: $OUTPUT_DIR"
+echo ""
+echo "Directory structure:"
+find "$OUTPUT_DIR" -name "*.a" -o -name "sfcgal_c.h" | sort

--- a/scripts/build-sfcgal-ios.sh
+++ b/scripts/build-sfcgal-ios.sh
@@ -27,8 +27,9 @@
 # Patches applied to SFCGAL source:
 #   - Removes hard-coded set(Boost_USE_STATIC_LIBS OFF) so the cache variable
 #     from our -DBoost_USE_STATIC_LIBS=ON takes effect.
-#   - Defines CGAL_DO_NOT_USE_BOOST_MP to ensure consistent type mangling
-#     across all translation units (prevents Gmpq vs boost::multiprecision mismatch).
+#   - Defines CMAKE_OVERRIDDEN_DEFAULT_ENT_BACKEND=0 (GMP_BACKEND) to ensure
+#     consistent CGAL exact-number-type resolution across all translation units
+#     (prevents Gmpq vs boost::multiprecision mismatch without disabling BMP).
 
 set -euo pipefail
 
@@ -131,14 +132,16 @@ sed -i.bak 's/^set(Boost_USE_STATIC_LIBS OFF)/#set(Boost_USE_STATIC_LIBS OFF)  #
 # CGAL::Lazy_exact_nt<boost::multiprecision::number<gmp_rational>>. This causes
 # linker failures because the mangled symbols differ.
 #
-# Fix: ensure CGAL uses its own Gmpq wrapper consistently by defining
-# CGAL_DO_NOT_USE_BOOST_MP, which prevents CGAL from using Boost.Multiprecision
-# wrappers for GMP types.
+# Fix: Override CGAL's default exact-number-type backend to GMP_BACKEND (enum=0).
+# This forces all translation units to resolve Exact_rational to CGAL::Gmpq
+# and Exact_integer to CGAL::Gmpz, while keeping Boost.Multiprecision support
+# available for code that uses it directly (e.g. straightSkeleton.cpp).
 echo "=== Patching: force consistent CGAL type resolution ==="
 cat >> "$SFCGAL_SRC/src/CMakeLists.txt" << 'PATCH'
 
-# Patched for iOS: ensure consistent CGAL::Gmpq usage across all translation units
-target_compile_definitions(SFCGAL PRIVATE CGAL_DO_NOT_USE_BOOST_MP)
+# Patched for iOS: force GMP_BACKEND for exact number types (enum value 0)
+# This ensures all TUs use CGAL::Gmpq without disabling Boost.Multiprecision
+target_compile_definitions(SFCGAL PRIVATE CMAKE_OVERRIDDEN_DEFAULT_ENT_BACKEND=0)
 PATCH
 
 # =============================================================================
@@ -276,6 +279,7 @@ build_sfcgal() {
         -DSFCGAL_BUILD_EXAMPLES=OFF \
         -DSFCGAL_BUILD_BENCH=OFF \
         -DCGAL_DIR="$CGAL_DIR/lib/cmake/CGAL" \
+        -DCGAL_CMAKE_EXACT_NT_BACKEND=GMP_BACKEND \
         -DCMAKE_PREFIX_PATH="$boost_prefix" \
         -DBoost_USE_STATIC_LIBS=ON \
         -DCGAL_Boost_USE_STATIC_LIBS=ON \

--- a/scripts/create-xcframeworks.sh
+++ b/scripts/create-xcframeworks.sh
@@ -75,18 +75,18 @@ stage_headers() {
 echo ""
 echo "=== Creating GMP.xcframework ==="
 
-GMP_MODULEMAP="module CGMP {
-    header \"gmp.h\"
-    link \"gmp\"
-    export *
-}"
+# GMP and MPFR don't get module maps — they are link-time dependencies only.
+# The SFCGAL module map includes `link "gmp"` and `link "mpfr"` directives
+# so the linker finds them. Omitting module maps avoids the Xcode build error
+# "Multiple commands produce .../include/module.modulemap" when multiple
+# xcframeworks each ship their own module.modulemap.
 
-# Stage headers with module maps for each slice
 GMP_IOS_HEADERS="${STAGING_DIR}/gmp-ios-arm64-headers"
 GMP_SIM_HEADERS="${STAGING_DIR}/gmp-sim-fat-headers"
 
-stage_headers "${GMP_BUILD}/ios-arm64/include" "$GMP_IOS_HEADERS" "$GMP_MODULEMAP"
-stage_headers "${GMP_BUILD}/simulator-arm64/include" "$GMP_SIM_HEADERS" "$GMP_MODULEMAP"
+mkdir -p "$GMP_IOS_HEADERS" "$GMP_SIM_HEADERS"
+cp -R "${GMP_BUILD}/ios-arm64/include"/* "$GMP_IOS_HEADERS"/
+cp -R "${GMP_BUILD}/simulator-arm64/include"/* "$GMP_SIM_HEADERS"/
 
 xcodebuild -create-xcframework \
     -library "${GMP_BUILD}/ios-arm64/lib/libgmp.a" \
@@ -102,17 +102,12 @@ echo "Created GMP.xcframework"
 echo ""
 echo "=== Creating MPFR.xcframework ==="
 
-MPFR_MODULEMAP="module CMPFR {
-    header \"mpfr.h\"
-    link \"mpfr\"
-    export *
-}"
-
 MPFR_IOS_HEADERS="${STAGING_DIR}/mpfr-ios-arm64-headers"
 MPFR_SIM_HEADERS="${STAGING_DIR}/mpfr-sim-fat-headers"
 
-stage_headers "${MPFR_BUILD}/ios-arm64/include" "$MPFR_IOS_HEADERS" "$MPFR_MODULEMAP"
-stage_headers "${MPFR_BUILD}/simulator-arm64/include" "$MPFR_SIM_HEADERS" "$MPFR_MODULEMAP"
+mkdir -p "$MPFR_IOS_HEADERS" "$MPFR_SIM_HEADERS"
+cp -R "${MPFR_BUILD}/ios-arm64/include"/* "$MPFR_IOS_HEADERS"/
+cp -R "${MPFR_BUILD}/simulator-arm64/include"/* "$MPFR_SIM_HEADERS"/
 
 xcodebuild -create-xcframework \
     -library "${MPFR_BUILD}/ios-arm64/lib/libmpfr.a" \
@@ -132,9 +127,11 @@ echo "=== Creating SFCGAL.xcframework ==="
 # SFCGAL/config.h and SFCGAL/export.h transitively.
 # We define SFCGAL_USE_STATIC_LIBS so that SFCGAL_API resolves to nothing
 # (correct for static linking — no dllimport/dllexport).
-SFCGAL_MODULEMAP="module CSFCGAL {
+SFCGAL_MODULEMAP="module CSFCGAL_Binary {
     header \"SFCGAL/capi/sfcgal_c.h\"
     link \"SFCGAL\"
+    link \"gmp\"
+    link \"mpfr\"
     export *
 }"
 

--- a/scripts/create-xcframeworks.sh
+++ b/scripts/create-xcframeworks.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# create-xcframeworks.sh
+#
+# Creates XCFrameworks for GMP, MPFR, and SFCGAL from the cross-compiled
+# iOS builds produced by build-gmp-ios.sh, build-mpfr-ios.sh, and
+# build-sfcgal-ios.sh.
+#
+# Each XCFramework contains:
+#   - iOS device slice (arm64)
+#   - iOS simulator slice (arm64 + x86_64 fat binary)
+#   - Module map for Swift interop
+#
+# Prerequisites:
+#   - Run build-gmp-ios.sh, build-mpfr-ios.sh, build-sfcgal-ios.sh first
+#   - Xcode command line tools installed
+#
+# Usage:
+#   ./scripts/create-xcframeworks.sh
+#
+# Output:
+#   xcframeworks/GMP.xcframework
+#   xcframeworks/MPFR.xcframework
+#   xcframeworks/SFCGAL.xcframework
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+GMP_BUILD="${PROJECT_DIR}/gmp-ios-build"
+MPFR_BUILD="${PROJECT_DIR}/mpfr-ios-build"
+SFCGAL_BUILD="${PROJECT_DIR}/sfcgal-ios-build"
+OUTPUT_DIR="${PROJECT_DIR}/xcframeworks"
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+
+echo "=== Validating cross-compiled builds ==="
+
+for lib_build in "$GMP_BUILD" "$MPFR_BUILD" "$SFCGAL_BUILD"; do
+    lib_name=$(basename "$lib_build")
+    for variant in ios-arm64 simulator-fat; do
+        if [ ! -d "${lib_build}/${variant}" ]; then
+            echo "ERROR: Missing ${lib_name}/${variant}. Run the build scripts first."
+            exit 1
+        fi
+    done
+done
+
+echo "All build outputs found."
+
+# ─── Prepare output directory ─────────────────────────────────────────────────
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# Use a temporary directory for staged headers (with module maps injected)
+STAGING_DIR=$(mktemp -d)
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+# ─── Helper: stage headers with module map ────────────────────────────────────
+
+stage_headers() {
+    local src_include="$1"    # e.g., gmp-ios-build/ios-arm64/include
+    local dest_dir="$2"       # staging directory for this slice
+    local modulemap="$3"      # module map content
+
+    mkdir -p "$dest_dir"
+    cp -R "$src_include"/* "$dest_dir"/
+    echo "$modulemap" > "$dest_dir/module.modulemap"
+}
+
+# ─── GMP XCFramework ─────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Creating GMP.xcframework ==="
+
+GMP_MODULEMAP="module CGMP {
+    header \"gmp.h\"
+    link \"gmp\"
+    export *
+}"
+
+# Stage headers with module maps for each slice
+GMP_IOS_HEADERS="${STAGING_DIR}/gmp-ios-arm64-headers"
+GMP_SIM_HEADERS="${STAGING_DIR}/gmp-sim-fat-headers"
+
+stage_headers "${GMP_BUILD}/ios-arm64/include" "$GMP_IOS_HEADERS" "$GMP_MODULEMAP"
+stage_headers "${GMP_BUILD}/simulator-arm64/include" "$GMP_SIM_HEADERS" "$GMP_MODULEMAP"
+
+xcodebuild -create-xcframework \
+    -library "${GMP_BUILD}/ios-arm64/lib/libgmp.a" \
+    -headers "$GMP_IOS_HEADERS" \
+    -library "${GMP_BUILD}/simulator-fat/lib/libgmp.a" \
+    -headers "$GMP_SIM_HEADERS" \
+    -output "${OUTPUT_DIR}/GMP.xcframework"
+
+echo "Created GMP.xcframework"
+
+# ─── MPFR XCFramework ────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Creating MPFR.xcframework ==="
+
+MPFR_MODULEMAP="module CMPFR {
+    header \"mpfr.h\"
+    link \"mpfr\"
+    export *
+}"
+
+MPFR_IOS_HEADERS="${STAGING_DIR}/mpfr-ios-arm64-headers"
+MPFR_SIM_HEADERS="${STAGING_DIR}/mpfr-sim-fat-headers"
+
+stage_headers "${MPFR_BUILD}/ios-arm64/include" "$MPFR_IOS_HEADERS" "$MPFR_MODULEMAP"
+stage_headers "${MPFR_BUILD}/simulator-arm64/include" "$MPFR_SIM_HEADERS" "$MPFR_MODULEMAP"
+
+xcodebuild -create-xcframework \
+    -library "${MPFR_BUILD}/ios-arm64/lib/libmpfr.a" \
+    -headers "$MPFR_IOS_HEADERS" \
+    -library "${MPFR_BUILD}/simulator-fat/lib/libmpfr.a" \
+    -headers "$MPFR_SIM_HEADERS" \
+    -output "${OUTPUT_DIR}/MPFR.xcframework"
+
+echo "Created MPFR.xcframework"
+
+# ─── SFCGAL XCFramework ──────────────────────────────────────────────────────
+
+echo ""
+echo "=== Creating SFCGAL.xcframework ==="
+
+# The SFCGAL module map exposes only the C API header. It includes
+# SFCGAL/config.h and SFCGAL/export.h transitively.
+# We define SFCGAL_USE_STATIC_LIBS so that SFCGAL_API resolves to nothing
+# (correct for static linking — no dllimport/dllexport).
+SFCGAL_MODULEMAP="module CSFCGAL {
+    header \"SFCGAL/capi/sfcgal_c.h\"
+    link \"SFCGAL\"
+    export *
+}"
+
+SFCGAL_IOS_HEADERS="${STAGING_DIR}/sfcgal-ios-arm64-headers"
+SFCGAL_SIM_HEADERS="${STAGING_DIR}/sfcgal-sim-fat-headers"
+
+stage_headers "${SFCGAL_BUILD}/ios-arm64/include" "$SFCGAL_IOS_HEADERS" "$SFCGAL_MODULEMAP"
+stage_headers "${SFCGAL_BUILD}/simulator-arm64/include" "$SFCGAL_SIM_HEADERS" "$SFCGAL_MODULEMAP"
+
+xcodebuild -create-xcframework \
+    -library "${SFCGAL_BUILD}/ios-arm64/lib/libSFCGAL.a" \
+    -headers "$SFCGAL_IOS_HEADERS" \
+    -library "${SFCGAL_BUILD}/simulator-fat/lib/libSFCGAL.a" \
+    -headers "$SFCGAL_SIM_HEADERS" \
+    -output "${OUTPUT_DIR}/SFCGAL.xcframework"
+
+echo "Created SFCGAL.xcframework"
+
+# ─── Verification ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Verifying XCFrameworks ==="
+
+for fw in GMP MPFR SFCGAL; do
+    fw_path="${OUTPUT_DIR}/${fw}.xcframework"
+    echo ""
+    echo "--- ${fw}.xcframework ---"
+
+    if [ ! -d "$fw_path" ]; then
+        echo "ERROR: ${fw}.xcframework not found!"
+        exit 1
+    fi
+
+    # Show Info.plist summary
+    echo "Slices:"
+    plutil -p "${fw_path}/Info.plist" | grep -E "LibraryIdentifier|LibraryPath|SupportedArchitectures|SupportedPlatform" || true
+
+    # Check architectures in each .a file
+    find "$fw_path" -name "*.a" | while read -r lib; do
+        echo ""
+        echo "  $(echo "$lib" | sed "s|${OUTPUT_DIR}/||")"
+        lipo -info "$lib"
+    done
+
+    # Verify module map exists in each slice
+    find "$fw_path" -name "module.modulemap" | while read -r mm; do
+        echo "  Module map: $(echo "$mm" | sed "s|${OUTPUT_DIR}/||")"
+    done
+done
+
+echo ""
+echo "=== Done ==="
+echo "XCFrameworks created in: ${OUTPUT_DIR}/"
+echo ""
+echo "Contents:"
+ls -1 "${OUTPUT_DIR}/"


### PR DESCRIPTION
## Summary

Implements the hybrid SPM package architecture described in #7:

- **macOS / Linux / Windows**: Uses `.systemLibrary` with `pkg-config` to link against a locally installed SFCGAL
- **iOS / tvOS / watchOS / visionOS**: Uses `.binaryTarget` with prebuilt XCFrameworks downloaded from GitHub releases
- **Compile-time version pinning**: A C++ `static_assert` in `version_check.cc` enforces that the installed SFCGAL version matches exactly `2.2.0`, preventing mismatches between the system library and XCFrameworks
- **CI on all platforms**: GitHub Actions workflow builds and tests on macOS, iOS Simulator, Linux (SFCGAL built from source), and Windows (SFCGAL built from source with vcpkg/MSVC)
- **Comprehensive README**: Step-by-step setup instructions for every platform, derived directly from the CI workflow
- **XCFramework build pipeline**: Scripts and workflow for cross-compiling GMP, MPFR, and SFCGAL for iOS and packaging as XCFrameworks

## Key files

| File | Purpose |
|------|---------|
| `Package.swift` | Hybrid package definition with platform-conditional dependencies |
| `Sources/CSFCGAL_System/` | System library target (modulemap + umbrella header) |
| `Sources/CSFCGAL_Shim/` | C shim with version macro + compile-time version check |
| `Sources/SwiftSFCGAL/` | Public Swift API |
| `.github/workflows/ci.yml` | CI: macOS, iOS Simulator, Linux, Windows |
| `.github/workflows/build-xcframeworks.yml` | XCFramework build + publish pipeline |
| `scripts/` | iOS cross-compilation scripts for GMP, MPFR, SFCGAL |

## Test plan

- [x] macOS: `swift build` + `swift test` with Homebrew SFCGAL
- [x] iOS Simulator: `xcodebuild build` with XCFrameworks from GitHub releases
- [x] Linux: `swift build` + `swift test` with SFCGAL 2.2.0 built from source
- [x] Windows: `swift build` + `swift test` with SFCGAL 2.2.0 built from source (MSVC + vcpkg)
- [x] Version mismatch rejected at compile time via `static_assert`

Closes #7