### PR TITLE
Implement batch geometry operations shim

### DIFF
--- a/Benchmarks/BatchOperationsBenchmark/main.swift
+++ b/Benchmarks/BatchOperationsBenchmark/main.swift
@@ -1,0 +1,123 @@
+import Foundation
+import SwiftSFCGAL
+
+private var benchmarkSink = 0
+
+@inline(never)
+private func consume(_ value: Int) {
+    benchmarkSink &+= value
+}
+
+private func median(_ values: [Double]) -> Double {
+    let sorted = values.sorted()
+    let middle = sorted.count / 2
+    if sorted.count % 2 == 0 {
+        return (sorted[middle - 1] + sorted[middle]) / 2.0
+    }
+    return sorted[middle]
+}
+
+private func measure(_ name: String,
+                     iterations: Int = 10,
+                     _ block: () throws -> Int) rethrows -> Double {
+    for _ in 0..<3 {
+        consume(try block())
+    }
+
+    var times: [Double] = []
+    times.reserveCapacity(iterations)
+    for _ in 0..<iterations {
+        let start = Date()
+        consume(try block())
+        times.append(Date().timeIntervalSince(start) * 1000.0)
+    }
+
+    let result = median(times)
+    print("\(name): \(String(format: "%.3f", result)) ms median")
+    return result
+}
+
+private func speedupPercent(baseline: Double, candidate: Double) -> Double {
+    guard baseline > 0 else { return 0 }
+    return ((baseline - candidate) / baseline) * 100.0
+}
+
+private func makeCityGMLSurfaceWKTs(buildingCount: Int = 20) -> [String] {
+    var surfaces: [String] = []
+    surfaces.reserveCapacity(buildingCount * 6)
+
+    for i in 0..<buildingCount {
+        let col = i % 5
+        let row = i / 5
+        let x = Double(col) * 18.0
+        let y = Double(row) * 16.0
+        let width = 8.0 + Double(i % 3)
+        let depth = 6.0 + Double(i % 4)
+        let height = 9.0 + Double(i % 5)
+        let roofRise = 2.0 + Double(i % 3) * 0.4
+        let x2 = x + width
+        let y2 = y + depth
+        let midY = y + depth / 2.0
+
+        surfaces.append("POLYGON((\(x) \(y),\(x2) \(y),\(x2) \(y2),\(x) \(y2),\(x) \(y)))")
+        surfaces.append("POLYGON Z((\(x) \(y) 0,\(x2) \(y) 0,\(x2) \(y) \(height),\(x) \(y) \(height),\(x) \(y) 0))")
+        surfaces.append("POLYGON Z((\(x2) \(y) 0,\(x2) \(y2) 0,\(x2) \(y2) \(height),\(x2) \(y) \(height),\(x2) \(y) 0))")
+        surfaces.append("POLYGON Z((\(x2) \(y2) 0,\(x) \(y2) 0,\(x) \(y2) \(height),\(x2) \(y2) \(height),\(x2) \(y2) 0))")
+        surfaces.append("POLYGON Z((\(x) \(y2) 0,\(x) \(y) 0,\(x) \(y) \(height),\(x) \(y2) \(height),\(x) \(y2) 0))")
+        surfaces.append("POLYGON Z((\(x) \(y) \(height),\(x2) \(y) \(height),\(x2) \(midY) \(height + roofRise),\(x) \(midY) \(height + roofRise),\(x) \(y) \(height)))")
+    }
+
+    return surfaces
+}
+
+private func run() throws {
+    initializeSFCGAL()
+
+    let wkts = makeCityGMLSurfaceWKTs()
+    let geometries = try wkts.map(Geometry.fromWKT)
+    let vertexCapacity = wkts.count * 64
+
+    print("Batch Operations Benchmark")
+    print("Surfaces: \(wkts.count)")
+    print("Iterations: 10 measured, 3 warmup")
+    print("")
+
+    let swiftLoop = try measure("Swift loop tesselate") {
+        let results = try geometries.map { try $0.tesselate() }
+        return results.count
+    }
+
+    let batchLoop = try measure("C batch tesselate") {
+        let results = try batchTesselate(geometries)
+        return results.count
+    }
+
+    let swiftPipeline = try measure("Swift WKT -> vertices pipeline") {
+        var total = 0
+        for wkt in wkts {
+            total += try Geometry.fromWKT(wkt).triangleVertices().count
+        }
+        return total
+    }
+
+    let cPipeline = try measure("C WKT -> vertices pipeline") {
+        let result = try batchWKTToVertices(wkts, vertexCapacity: vertexCapacity)
+        return result.vertices.count
+    }
+
+    let tessSpeedup = speedupPercent(baseline: swiftLoop, candidate: batchLoop)
+    let pipelineSpeedup = speedupPercent(baseline: swiftPipeline, candidate: cPipeline)
+
+    print("")
+    print("Batch tesselate speedup: \(String(format: "%.2f", tessSpeedup))%")
+    print("WKT-to-vertices speedup: \(String(format: "%.2f", pipelineSpeedup))%")
+    if tessSpeedup < 5.0 {
+        print("Batch tesselate is below the 5% public API threshold on this run.")
+    }
+    if pipelineSpeedup < 5.0 {
+        print("WKT-to-vertices is below the 5% threshold on this run.")
+    }
+    consume(benchmarkSink)
+}
+
+try run()

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,0 +1,57 @@
+# Benchmarks
+
+This folder contains reproducible benchmarks for APIs whose value depends on
+reducing Swift/C boundary overhead.
+
+## Batch Operations
+
+Run the benchmark in release mode.
+
+macOS/Linux:
+
+```bash
+swift run -c release BatchOperationsBenchmark
+```
+
+Windows with SFCGAL installed to `C:\sfcgal`:
+
+```powershell
+swift run -c release -Xcc -IC:/sfcgal/include -Xlinker /LIBPATH:C:\sfcgal\lib BatchOperationsBenchmark
+```
+
+The benchmark generates 120 CityGML-like building surfaces and compares:
+
+- Swift loop: `geometries.map { try $0.tesselate() }`
+- C batch: `batchTesselate(geometries)`
+- Swift pipeline: WKT parse -> tesselate -> vertex extraction in Swift
+- C pipeline: `batchWKTToVertices(_:vertexCapacity:)`
+
+Issue 8.1 uses a 5% threshold: if plain batch tesselation is under that
+threshold, the API should be reconsidered. The WKT-to-vertices pipeline is
+tracked separately because it removes more intermediate Swift object traffic.
+
+## Latest Local Result
+
+Recorded on Windows, Swift 6.1 release build, SFCGAL installed at `C:\sfcgal`,
+using the generated 120-surface CityGML-like benchmark workload:
+
+```text
+Batch Operations Benchmark
+Surfaces: 120
+Iterations: 10 measured, 3 warmup
+
+Swift loop tesselate: 43.379 ms median
+C batch tesselate: 44.564 ms median
+Swift WKT -> vertices pipeline: 39.400 ms median
+C WKT -> vertices pipeline: 38.638 ms median
+
+Batch tesselate speedup: -2.73%
+WKT-to-vertices speedup: 1.93%
+Batch tesselate is below the 5% public API threshold on this run.
+WKT-to-vertices is below the 5% threshold on this run.
+```
+
+This result does not satisfy the Issue 8.1 threshold for keeping a public batch
+tesselation API. Before closing the issue, rerun this benchmark against a real
+CityGML sample with at least 100 building surfaces and document that result in
+the GitHub issue.

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     ],
     products: [
         .library(name: "SwiftSFCGAL", targets: ["SwiftSFCGAL"]),
+        .executable(name: "BatchOperationsBenchmark", targets: ["BatchOperationsBenchmark"]),
     ],
     targets: [
         // ── The public Swift API ──
@@ -68,6 +69,12 @@ let package = Package(
         ),
 
         // ── Tests ──
+        .executableTarget(
+            name: "BatchOperationsBenchmark",
+            dependencies: ["SwiftSFCGAL"],
+            path: "Benchmarks/BatchOperationsBenchmark"
+        ),
+
         .testTarget(name: "SwiftSFCGALTests", dependencies: ["SwiftSFCGAL", "CSFCGAL_Shim"]),
     ]
 )

--- a/Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
+++ b/Sources/CSFCGAL_Shim/include/sfcgal_swift_shim.h
@@ -64,4 +64,32 @@ size_t sfcgal_swift_batch_tesselate(const sfcgal_geometry_t *const *geometries,
                                     size_t count,
                                     sfcgal_geometry_t **out_results);
 
+/// Like sfcgal_swift_batch_tesselate, but also fills out_errors[i] with a
+/// pointer to a thread-local static error string for each failed geometry
+/// (NULL on success). Strings are valid until the next call on this thread.
+///
+/// Returns the number of geometries successfully tesselated.
+size_t sfcgal_swift_batch_tesselate_ex(
+    const sfcgal_geometry_t *const *geometries,
+    size_t count,
+    sfcgal_geometry_t **out_results,
+    const char **out_errors);
+
+/// Parse WKT -> tesselate -> extract interleaved x,y,z vertex data in one call.
+/// Designed for GPU upload pipelines (e.g. CityGML surfaces -> RealityKit mesh).
+///
+/// out_vertices:      caller-allocated float buffer (interleaved x,y,z triples)
+/// out_vertex_counts: caller-allocated array of count size_t slots;
+///                    out_vertex_counts[i] is the number of vertices for geometry i
+/// out_capacity:      total capacity of out_vertices in number of floats
+///
+/// Returns total floats written, or 0 on complete failure. Check
+/// sfcgal_swift_has_error() for partial failures.
+size_t sfcgal_swift_batch_wkt_to_vertices(
+    const char **wkt_inputs,
+    size_t count,
+    float *out_vertices,
+    size_t *out_vertex_counts,
+    size_t out_capacity);
+
 #endif /* SFCGAL_SWIFT_SHIM_H */

--- a/Sources/CSFCGAL_Shim/sfcgal_swift_shim.c
+++ b/Sources/CSFCGAL_Shim/sfcgal_swift_shim.c
@@ -24,6 +24,8 @@
 static THREAD_LOCAL char sfcgal_error_buf[2048]   = {0};
 static THREAD_LOCAL char sfcgal_warning_buf[2048] = {0};
 static THREAD_LOCAL int  sfcgal_error_flag        = 0;
+static THREAD_LOCAL char (*sfcgal_batch_error_bufs)[2048] = NULL;
+static THREAD_LOCAL size_t sfcgal_batch_error_capacity = 0;
 
 // sfcgal_error_handler_t is: int (*)(const char *fmt, ...)
 // Return value is ignored by SFCGAL; we return 0.
@@ -84,11 +86,104 @@ void sfcgal_swift_inject_warning_for_testing(const char *message) {
     swift_warning_handler("%s", message);
 }
 
+static void sfcgal_swift_set_last_error_message(const char *message) {
+    if (message == NULL || message[0] == '\0') {
+        message = "Unknown SFCGAL error";
+    }
+    snprintf(sfcgal_error_buf, sizeof(sfcgal_error_buf), "%s", message);
+    sfcgal_error_flag = 1;
+}
+
+static const char *sfcgal_swift_current_error_or(const char *fallback) {
+    const char *message = sfcgal_swift_get_last_error();
+    if (message == NULL || message[0] == '\0') {
+        return fallback;
+    }
+    return message;
+}
+
+static int sfcgal_swift_ensure_batch_error_capacity(size_t count) {
+    if (count <= sfcgal_batch_error_capacity) {
+        return 1;
+    }
+
+    char (*new_bufs)[2048] = (char (*)[2048])realloc(
+        sfcgal_batch_error_bufs,
+        count * sizeof(*sfcgal_batch_error_bufs));
+    if (new_bufs == NULL) {
+        sfcgal_swift_set_last_error_message("Unable to allocate batch error storage");
+        return 0;
+    }
+
+    sfcgal_batch_error_bufs = new_bufs;
+    sfcgal_batch_error_capacity = count;
+    return 1;
+}
+
+static const char *sfcgal_swift_store_batch_error(size_t index,
+                                                  const char *message) {
+    snprintf(sfcgal_batch_error_bufs[index],
+             sizeof(sfcgal_batch_error_bufs[index]),
+             "%s",
+             message == NULL ? "Unknown SFCGAL error" : message);
+    return sfcgal_batch_error_bufs[index];
+}
+
+static void sfcgal_swift_remember_failure(char *last_error,
+                                          size_t last_error_size,
+                                          const char *message) {
+    snprintf(last_error,
+             last_error_size,
+             "%s",
+             message == NULL ? "Unknown SFCGAL error" : message);
+}
+
 size_t sfcgal_swift_batch_tesselate(const sfcgal_geometry_t *const *geometries,
                                     size_t count,
                                     sfcgal_geometry_t **out_results) {
+    return sfcgal_swift_batch_tesselate_ex(geometries, count, out_results, NULL);
+}
+
+size_t sfcgal_swift_batch_tesselate_ex(
+    const sfcgal_geometry_t *const *geometries,
+    size_t count,
+    sfcgal_geometry_t **out_results,
+    const char **out_errors) {
+    if (count == 0) {
+        return 0;
+    }
+
+    if (geometries == NULL || out_results == NULL) {
+        sfcgal_swift_set_last_error_message("Batch tesselate received NULL input arrays");
+        return 0;
+    }
+
+    if (out_errors != NULL && !sfcgal_swift_ensure_batch_error_capacity(count)) {
+        return 0;
+    }
+
     size_t success = 0;
+    int had_failure = 0;
+    char last_error[2048] = {0};
+
     for (size_t i = 0; i < count; i++) {
+        out_results[i] = NULL;
+        if (out_errors != NULL) {
+            out_errors[i] = NULL;
+        }
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        if (geometries[i] == NULL) {
+            const char *message = "Input geometry is NULL";
+            if (out_errors != NULL) {
+                out_errors[i] = sfcgal_swift_store_batch_error(i, message);
+            }
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
+            continue;
+        }
+
         sfcgal_swift_clear_errors();
         out_results[i] = sfcgal_geometry_tesselate(geometries[i]);
         if (out_results[i] != NULL && !sfcgal_swift_has_error()) {
@@ -99,7 +194,226 @@ size_t sfcgal_swift_batch_tesselate(const sfcgal_geometry_t *const *geometries,
                 sfcgal_geometry_delete(out_results[i]);
                 out_results[i] = NULL;
             }
+            const char *message = sfcgal_swift_current_error_or("Tesselation failed");
+            if (out_errors != NULL) {
+                out_errors[i] = sfcgal_swift_store_batch_error(i, message);
+            }
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
         }
     }
+
+    if (had_failure) {
+        sfcgal_swift_set_last_error_message(last_error);
+    } else {
+        sfcgal_swift_clear_errors();
+    }
+
     return success;
+}
+
+static size_t sfcgal_swift_count_vertices(const sfcgal_geometry_t *geometry) {
+    if (geometry == NULL) {
+        return 0;
+    }
+
+    switch (sfcgal_geometry_type_id(geometry)) {
+    case SFCGAL_TYPE_TRIANGLE:
+        return 3;
+    case SFCGAL_TYPE_TRIANGULATEDSURFACE:
+        return sfcgal_triangulated_surface_num_patches(geometry) * 3;
+    case SFCGAL_TYPE_GEOMETRYCOLLECTION: {
+        size_t total = 0;
+        size_t count = sfcgal_geometry_num_geometries(geometry);
+        for (size_t i = 0; i < count; i++) {
+            const sfcgal_geometry_t *child =
+                sfcgal_geometry_collection_geometry_n(geometry, i);
+            total += sfcgal_swift_count_vertices(child);
+        }
+        return total;
+    }
+    default:
+        return 0;
+    }
+}
+
+static size_t sfcgal_swift_append_triangle_vertices(const sfcgal_geometry_t *triangle,
+                                                    float *out_vertices,
+                                                    size_t offset,
+                                                    size_t out_capacity) {
+    if (triangle == NULL || out_vertices == NULL || offset + 9 > out_capacity) {
+        return (size_t)-1;
+    }
+
+    for (int i = 0; i < 3; i++) {
+        const sfcgal_geometry_t *point = sfcgal_triangle_vertex(triangle, i);
+        if (point == NULL) {
+            return (size_t)-1;
+        }
+
+        out_vertices[offset++] = (float)sfcgal_point_x(point);
+        out_vertices[offset++] = (float)sfcgal_point_y(point);
+        out_vertices[offset++] =
+            sfcgal_geometry_is_3d(point) ? (float)sfcgal_point_z(point) : 0.0f;
+    }
+
+    return 9;
+}
+
+static size_t sfcgal_swift_append_vertices(const sfcgal_geometry_t *geometry,
+                                           float *out_vertices,
+                                           size_t offset,
+                                           size_t out_capacity) {
+    if (geometry == NULL) {
+        return 0;
+    }
+
+    switch (sfcgal_geometry_type_id(geometry)) {
+    case SFCGAL_TYPE_TRIANGLE:
+        return sfcgal_swift_append_triangle_vertices(
+            geometry,
+            out_vertices,
+            offset,
+            out_capacity);
+    case SFCGAL_TYPE_TRIANGULATEDSURFACE: {
+        size_t written = 0;
+        size_t count = sfcgal_triangulated_surface_num_patches(geometry);
+        for (size_t i = 0; i < count; i++) {
+            const sfcgal_geometry_t *triangle =
+                sfcgal_triangulated_surface_patch_n(geometry, i);
+            size_t n = sfcgal_swift_append_triangle_vertices(
+                triangle,
+                out_vertices,
+                offset + written,
+                out_capacity);
+            if (n == (size_t)-1) {
+                return (size_t)-1;
+            }
+            written += n;
+        }
+        return written;
+    }
+    case SFCGAL_TYPE_GEOMETRYCOLLECTION: {
+        size_t written = 0;
+        size_t count = sfcgal_geometry_num_geometries(geometry);
+        for (size_t i = 0; i < count; i++) {
+            const sfcgal_geometry_t *child =
+                sfcgal_geometry_collection_geometry_n(geometry, i);
+            size_t n = sfcgal_swift_append_vertices(
+                child,
+                out_vertices,
+                offset + written,
+                out_capacity);
+            if (n == (size_t)-1) {
+                return (size_t)-1;
+            }
+            written += n;
+        }
+        return written;
+    }
+    default:
+        return 0;
+    }
+}
+
+size_t sfcgal_swift_batch_wkt_to_vertices(
+    const char **wkt_inputs,
+    size_t count,
+    float *out_vertices,
+    size_t *out_vertex_counts,
+    size_t out_capacity) {
+    if (count == 0) {
+        return 0;
+    }
+
+    if (wkt_inputs == NULL || out_vertex_counts == NULL ||
+        (out_capacity > 0 && out_vertices == NULL)) {
+        sfcgal_swift_set_last_error_message("Batch WKT-to-vertices received NULL input arrays");
+        return 0;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        out_vertex_counts[i] = 0;
+    }
+
+    size_t total_floats = 0;
+    int had_failure = 0;
+    char last_error[2048] = {0};
+
+    for (size_t i = 0; i < count; i++) {
+        if (wkt_inputs[i] == NULL) {
+            const char *message = "Input WKT is NULL";
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
+            continue;
+        }
+
+        sfcgal_swift_clear_errors();
+        sfcgal_geometry_t *geometry =
+            sfcgal_io_read_wkt(wkt_inputs[i], strlen(wkt_inputs[i]));
+        if (geometry == NULL || sfcgal_swift_has_error()) {
+            if (geometry != NULL) {
+                sfcgal_geometry_delete(geometry);
+            }
+            const char *message = sfcgal_swift_current_error_or("Failed to parse WKT");
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
+            continue;
+        }
+
+        sfcgal_swift_clear_errors();
+        sfcgal_geometry_t *tessellated = sfcgal_geometry_tesselate(geometry);
+        sfcgal_geometry_delete(geometry);
+        if (tessellated == NULL || sfcgal_swift_has_error()) {
+            if (tessellated != NULL) {
+                sfcgal_geometry_delete(tessellated);
+            }
+            const char *message = sfcgal_swift_current_error_or("Tesselation failed");
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
+            continue;
+        }
+
+        size_t vertex_count = sfcgal_swift_count_vertices(tessellated);
+        size_t float_count = vertex_count * 3;
+        if (vertex_count > 0 && float_count / 3 != vertex_count) {
+            sfcgal_geometry_delete(tessellated);
+            const char *message = "Vertex count overflow";
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
+            continue;
+        }
+
+        if (float_count > out_capacity - total_floats) {
+            sfcgal_geometry_delete(tessellated);
+            const char *message = "Output vertex buffer capacity exceeded";
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
+            continue;
+        }
+
+        size_t written = sfcgal_swift_append_vertices(
+            tessellated,
+            out_vertices,
+            total_floats,
+            out_capacity);
+        sfcgal_geometry_delete(tessellated);
+        if (written == (size_t)-1 || written != float_count) {
+            const char *message = "Failed to extract tesselated vertices";
+            sfcgal_swift_remember_failure(last_error, sizeof(last_error), message);
+            had_failure = 1;
+            continue;
+        }
+
+        out_vertex_counts[i] = vertex_count;
+        total_floats += written;
+    }
+
+    if (had_failure) {
+        sfcgal_swift_set_last_error_message(last_error);
+    } else {
+        sfcgal_swift_clear_errors();
+    }
+
+    return total_floats;
 }

--- a/Sources/SwiftSFCGAL/Geometry+Batch.swift
+++ b/Sources/SwiftSFCGAL/Geometry+Batch.swift
@@ -1,0 +1,154 @@
+#if canImport(CSFCGAL_System)
+import CSFCGAL_System
+#elseif canImport(CSFCGAL_Binary)
+import CSFCGAL_Binary
+#endif
+import CSFCGAL_Shim
+
+/// Error thrown by batch geometry APIs when one or more input geometries fail.
+public struct BatchGeometryError: Error, CustomStringConvertible {
+    /// Maps input indexes to their per-geometry error messages.
+    public let failures: [Int: String]
+
+    public init(failures: [Int: String]) {
+        self.failures = failures
+    }
+
+    public var description: String {
+        let details = failures
+            .sorted { $0.key < $1.key }
+            .map { "index \($0.key): \($0.value)" }
+            .joined(separator: "; ")
+        return "SFCGAL batch operation failed: \(details)"
+    }
+}
+
+/// Result of a batched WKT -> tesselated vertices pipeline.
+public struct BatchVertexResult {
+    /// Interleaved x,y,z float triples.
+    public let vertices: [Float]
+
+    /// Number of vertices produced for each input WKT.
+    public let vertexCounts: [Int]
+
+    public init(vertices: [Float], vertexCounts: [Int]) {
+        self.vertices = vertices
+        self.vertexCounts = vertexCounts
+    }
+}
+
+/// Tesselates multiple geometries in one C-level call.
+///
+/// This avoids repeated Swift->C calls when processing large geometry batches,
+/// such as many CityGML wall or roof surfaces. If any geometry fails, all
+/// successful intermediate C results are released and a `BatchGeometryError`
+/// reports the failed input indexes.
+public func batchTesselate(_ geometries: [Geometry]) throws -> [Geometry] {
+    guard !geometries.isEmpty else { return [] }
+
+    let inputs: [UnsafeRawPointer?] = geometries.map { UnsafeRawPointer($0.handle) }
+    var outputs = Array<UnsafeMutableRawPointer?>(repeating: nil, count: geometries.count)
+    var errorPointers = Array<UnsafePointer<CChar>?>(repeating: nil, count: geometries.count)
+
+    let successCount = inputs.withUnsafeBufferPointer { inputBuffer in
+        outputs.withUnsafeMutableBufferPointer { outputBuffer in
+            errorPointers.withUnsafeMutableBufferPointer { errorBuffer in
+                sfcgal_swift_batch_tesselate_ex(
+                    inputBuffer.baseAddress,
+                    geometries.count,
+                    outputBuffer.baseAddress,
+                    errorBuffer.baseAddress)
+            }
+        }
+    }
+
+    guard Int(successCount) == geometries.count else {
+        var failures: [Int: String] = [:]
+        for (index, pointer) in errorPointers.enumerated() {
+            if let pointer {
+                failures[index] = String(cString: pointer)
+            }
+        }
+        if failures.isEmpty, let pointer = sfcgal_swift_get_last_error() {
+            failures[0] = String(cString: pointer)
+        }
+        if failures.isEmpty {
+            failures[0] = "Batch tesselation failed"
+        }
+        for output in outputs {
+            if let output {
+                sfcgal_geometry_delete(output)
+            }
+        }
+        throw BatchGeometryError(failures: failures)
+    }
+
+    if let missingIndex = outputs.firstIndex(where: { $0 == nil }) {
+        for output in outputs {
+            if let output {
+                sfcgal_geometry_delete(output)
+            }
+        }
+        throw BatchGeometryError(failures: [missingIndex: "Batch tesselation returned a NULL result"])
+    }
+
+    return outputs.map { makeGeometry(handle: $0!, ownsHandle: true) }
+}
+
+/// Parse WKT, tesselate, and extract interleaved x,y,z vertices in one C call.
+///
+/// `vertexCapacity` is measured in floats, not vertices. For example, a single
+/// triangle needs capacity for 9 floats. If the buffer is too small, the
+/// function throws and no partial Swift result is returned.
+public func batchWKTToVertices(_ wktInputs: [String],
+                               vertexCapacity: Int) throws -> BatchVertexResult {
+    guard vertexCapacity >= 0 else {
+        throw SFCGALError.operationFailed("vertexCapacity must be non-negative")
+    }
+    guard !wktInputs.isEmpty else {
+        return BatchVertexResult(vertices: [], vertexCounts: [])
+    }
+
+    let cStrings = wktInputs.map { makeCString($0) }
+    defer {
+        for cString in cStrings {
+            cString.pointer.deinitialize(count: cString.count)
+            cString.pointer.deallocate()
+        }
+    }
+
+    var inputPointers: [UnsafePointer<CChar>?] = cStrings.map { UnsafePointer($0.pointer) }
+    var vertices = Array<Float>(repeating: 0, count: vertexCapacity)
+    var vertexCounts = Array<Int>(repeating: 0, count: wktInputs.count)
+
+    let floatsWritten = inputPointers.withUnsafeMutableBufferPointer { inputBuffer in
+        vertices.withUnsafeMutableBufferPointer { vertexBuffer in
+            vertexCounts.withUnsafeMutableBufferPointer { countBuffer in
+                sfcgal_swift_batch_wkt_to_vertices(
+                    inputBuffer.baseAddress,
+                    wktInputs.count,
+                    vertexBuffer.baseAddress,
+                    countBuffer.baseAddress,
+                    vertexCapacity)
+            }
+        }
+    }
+
+    if sfcgal_swift_has_error() != 0 {
+        let message = sfcgal_swift_get_last_error().map(String.init(cString:))
+            ?? "Batch WKT-to-vertices failed"
+        throw SFCGALError.operationFailed(message)
+    }
+
+    vertices.removeSubrange(Int(floatsWritten)..<vertices.count)
+    return BatchVertexResult(vertices: vertices, vertexCounts: vertexCounts)
+}
+
+private func makeCString(_ string: String) -> (pointer: UnsafeMutablePointer<CChar>, count: Int) {
+    let utf8 = Array(string.utf8CString)
+    let pointer = UnsafeMutablePointer<CChar>.allocate(capacity: utf8.count)
+    for (index, char) in utf8.enumerated() {
+        pointer.advanced(by: index).initialize(to: char)
+    }
+    return (pointer, utf8.count)
+}

--- a/Tests/SwiftSFCGALTests/BatchOperationsTests.swift
+++ b/Tests/SwiftSFCGALTests/BatchOperationsTests.swift
@@ -1,0 +1,128 @@
+import Testing
+@testable import SwiftSFCGAL
+import CSFCGAL_Shim
+
+@Test func testBatchTesselateExPerGeometryErrors() throws {
+    TestSupport.initializeSFCGALOnce()
+
+    let square = try TestGeometry.fromWKT(GeometryFixtures.Polygons2D.unitSquare)
+    let triangle = try TestGeometry.fromWKT(GeometryFixtures.Polygons2D.unitTriangle)
+
+    let inputs: [UnsafeRawPointer?] = [
+        UnsafeRawPointer(square.handle),
+        nil,
+        UnsafeRawPointer(triangle.handle),
+    ]
+    var outputs = Array<UnsafeMutableRawPointer?>(repeating: nil, count: inputs.count)
+    var errors = Array<UnsafePointer<CChar>?>(repeating: nil, count: inputs.count)
+
+    let successCount = inputs.withUnsafeBufferPointer { inputBuffer in
+        outputs.withUnsafeMutableBufferPointer { outputBuffer in
+            errors.withUnsafeMutableBufferPointer { errorBuffer in
+                sfcgal_swift_batch_tesselate_ex(
+                    inputBuffer.baseAddress,
+                    inputs.count,
+                    outputBuffer.baseAddress,
+                    errorBuffer.baseAddress)
+            }
+        }
+    }
+    defer {
+        for output in outputs {
+            if let output {
+                sfcgal_geometry_delete(output)
+            }
+        }
+    }
+
+    #expect(Int(successCount) == 2)
+    #expect(outputs[0] != nil)
+    #expect(outputs[1] == nil)
+    #expect(outputs[2] != nil)
+    #expect(errors[0] == nil)
+    #expect(errors[1] != nil)
+    #expect(errors[2] == nil)
+    #expect(String(cString: errors[1]!).contains("NULL"))
+    #expect(sfcgal_swift_has_error() == 1)
+}
+
+@Test func testBatchTesselateSwiftAPI() throws {
+    TestSupport.initializeSFCGALOnce()
+
+    let square = try TestGeometry.fromWKT(GeometryFixtures.Polygons2D.unitSquare)
+    let wall = try TestGeometry.fromWKT(GeometryFixtures.Polygons3D.verticalWall)
+
+    let results = try batchTesselate([square, wall])
+
+    #expect(results.count == 2)
+    #expect(results[0] is TriangulatedSurface)
+    #expect(results[1] is TriangulatedSurface)
+    #expect(results[0].isValid)
+    #expect(results[1].isValid)
+}
+
+@Test func testBatchTesselateSwiftAPIEmptyInput() throws {
+    TestSupport.initializeSFCGALOnce()
+
+    let results = try batchTesselate([])
+
+    #expect(results.isEmpty)
+}
+
+@Test func testBatchWktToVertices() throws {
+    TestSupport.initializeSFCGALOnce()
+
+    let wkts = [
+        "POLYGON((0 0,1 0,0 1,0 0))",
+        "POLYGON((2 0,3 0,2 1,2 0))",
+        "POLYGON Z((0 0 1,1 0 1,0 1 2,0 0 1))",
+    ]
+
+    let result = try batchWKTToVertices(wkts, vertexCapacity: 64)
+
+    #expect(result.vertexCounts == [3, 3, 3])
+    #expect(result.vertices.count == 27)
+    #expect(vertexTripleSet(result.vertices) == Set([
+        "0,0,0",
+        "1000,0,0",
+        "0,1000,0",
+        "2000,0,0",
+        "3000,0,0",
+        "2000,1000,0",
+        "0,0,1000",
+        "1000,0,1000",
+        "0,1000,2000",
+    ]))
+}
+
+@Test func testBatchWktToVerticesInvalidWKTThrows() {
+    TestSupport.initializeSFCGALOnce()
+
+    #expect(throws: SFCGALError.self) {
+        _ = try batchWKTToVertices([
+            "POLYGON((0 0,1 0,0 1,0 0))",
+            "NOT VALID WKT",
+        ], vertexCapacity: 64)
+    }
+}
+
+@Test func testBatchWktToVerticesInsufficientCapacityThrows() {
+    TestSupport.initializeSFCGALOnce()
+
+    #expect(throws: SFCGALError.self) {
+        _ = try batchWKTToVertices([
+            "POLYGON((0 0,1 0,0 1,0 0))",
+        ], vertexCapacity: 8)
+    }
+}
+
+private func vertexTripleSet(_ vertices: [Float]) -> Set<String> {
+    var triples = Set<String>()
+    for i in stride(from: 0, to: vertices.count, by: 3) {
+        let x = Int((vertices[i] * 1000).rounded())
+        let y = Int((vertices[i + 1] * 1000).rounded())
+        let z = Int((vertices[i + 2] * 1000).rounded())
+        triples.insert("\(x),\(y),\(z)")
+    }
+    return triples
+}


### PR DESCRIPTION
Add the Issue 8.1 batch operations layer, including per-geometry error reporting for batch tessellation, a WKT-to-vertices C pipeline, Swift batch APIs, focused tests, and a benchmark target.

Includes:
- `sfcgal_swift_batch_tesselate_ex`
- `sfcgal_swift_batch_wkt_to_vertices`
- `batchTesselate(_:)`
- `batchWKTToVertices(_:vertexCapacity:)`
- batch operation tests
- release benchmark documentation and local Windows benchmark result

Known limitation:
- The benchmark currently uses generated CityGML-like surfaces, not a real CityGML dataset.
- Local Windows benchmark results are below the issue’s 5% threshold:
  - `batchTesselate`: `-2.73%`
  - `batchWKTToVertices`: `1.93%`
- Per Issue 8.1, the public batch tessellation API should be reconsidered or removed unless real CityGML benchmark data shows at least a 5% speedup.

Verification:
- `swift test -Xcc -IC:/sfcgal/include -Xlinker /LIBPATH:C:\sfcgal\lib`
- Full suite passed: `240` tests.